### PR TITLE
Fix two issues in the checks

### DIFF
--- a/check_fr30_collide.py
+++ b/check_fr30_collide.py
@@ -14,6 +14,8 @@ import logging
 from openlcb.nodeid import NodeID
 from openlcb.canbus.canframe import CanFrame
 from openlcb.canbus.controlframe import ControlFrame
+from openlcb.message import Message
+from openlcb.mti import MTI
 from queue import Empty
 
 import olcbchecker.setup
@@ -89,7 +91,12 @@ def check():
         if (reply.header & 0xFF_FFF_000) != 0x10_703_000 :
             logger.warning ("Failure - frame was not AMR frame in second part")
             return 3
-                
+
+        # Sends a global verify node ID message, forcing the target node to
+        # allocate a new alias.
+        message = Message(MTI.Verify_NodeID_Number_Global, NodeID(olcbchecker.setup.configure.ownnodeid), None)
+        olcbchecker.sendMessage(message)        
+        
         # loop for _optional_ CID 7 frame and eventual AMD with different alias
         newAlias = 0  # zero indicates invalid, not allocated
         amdReceived = False

--- a/check_mc20_ckasi.py
+++ b/check_mc20_ckasi.py
@@ -141,7 +141,7 @@ def check():
             logger.warning (("Failure: space 0x{:02X} improper flag bits set").format(space))
             return (3)
     
-        if (reply.data[7]*0x01) != 0 :
+        if (reply.data[7]&0x02) != 0 :
             # check that low address is present
             if len(reply.data) < 12 :
                 logger.warning (("Failure: space 0x{:02X} flagged containing low address but not present").format(space))


### PR DESCRIPTION
Adds a Verify Node ID Global message after the alias collision test. 

The alias collision test can leave the target under test in an Inhibited
state, i.e., without an alias. This is standard-compliant. However, at
that point all further tests will fail, because the test script does not
correctly address the target under test anymore.

Adding the global verify node ID ensures that the target under test sends
a reply, and as part of this reply it will always allocate a new alias.

Other methods such as sending an unaddressed AME will not trigger a reply
from nodes that are in Inhibited state.

===

Fixes address space information reply check which was using incorrect
arithmetics to check for a given bit.
