### PR TITLE
Add close on exit to the control_*.py files

### DIFF
--- a/control_cdi.py
+++ b/control_cdi.py
@@ -73,5 +73,8 @@ def main() :
             case _ : continue
                    
     return
+
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_datagram.py
+++ b/control_datagram.py
@@ -55,5 +55,8 @@ def main() :
             case _ : continue
                    
     return
+
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_events.py
+++ b/control_events.py
@@ -80,4 +80,6 @@ def main() :
                    
     return
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_frame.py
+++ b/control_frame.py
@@ -84,5 +84,8 @@ def main() :
             case _ : continue
                    
     return
+
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_memory.py
+++ b/control_memory.py
@@ -92,4 +92,6 @@ def main() :
                    
     return
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_message.py
+++ b/control_message.py
@@ -87,5 +87,8 @@ def main() :
             case _ : continue
                    
     return
+
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_setup.py
+++ b/control_setup.py
@@ -86,6 +86,7 @@ def main() :
             case _ : continue
 
 
-
 if __name__ == "__main__":
-    main()
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_snip.py
+++ b/control_snip.py
@@ -55,5 +55,8 @@ def main() :
             case _ : continue
                    
     return
+
 if __name__ == "__main__":
-    sys.exit(main())
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)


### PR DESCRIPTION
This will require the latest 0.1.2 tag of the python_openlcb project or later.

Note this does not update the `check_*.py` files.  Those will come later, once it's seen whether this change to the `control_*.py` files works or not to resolve Issue #7.