### PR TITLE
Add Stream Transport protocol tests and update existing tests to use …

### DIFF
--- a/check_cd20_read.py
+++ b/check_cd20_read.py
@@ -207,9 +207,45 @@ def check():
         return 3
     
     if retval == 0 :
-        logger.info("Passed")
+        logger.info("Passed (datagram)")
     else :
         logger.info("Failed {} checks, see above".format(str(retval)))
+        return retval
+
+    # --- Stream read pass ---
+    from olcbchecker.stream_utils import query_stream_support, read_via_stream
+    from openlcb.pip import PIP as PIP_enum
+
+    stream_ok = query_stream_support(destination)
+    if not stream_ok :
+        logger.info("Skipped (stream) - Config Options stream bit not set")
+        return 0
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is not None and PIP_enum.STREAM_PROTOCOL not in pipSet :
+            logger.info("Skipped (stream) - Stream protocol not in PIP")
+            return 0
+
+    try :
+        # Read entire CDI via stream (length=0 means read to end)
+        stream_data = read_via_stream(logger, destination, 0xFF, 0, 0)
+
+        # Compare stream data to datagram-read content (already in 'content')
+        # Both should contain the same bytes up to the null terminator
+        if list(stream_data[:len(content)]) != content :
+            logger.warning("Failure (stream) - CDI via stream does not match "
+                           "CDI via datagram ({} stream bytes vs {} "
+                           "datagram bytes)"
+                           .format(len(stream_data), len(content)))
+            return 3
+
+        logger.info("Passed (stream)")
+
+    except Exception as e :
+        logger.warning("Failure (stream) - {}".format(str(e)))
+        return 3
+
     return retval
 
 if __name__ == "__main__":

--- a/check_fd20_read.py
+++ b/check_fd20_read.py
@@ -210,10 +210,45 @@ def check():
         logger.warning("Failure - FDI XML "+str(e))
         retval = retval+1
     
-    if retval == 0 : 
-        logger.info("Passed")
-    else : 
+    if retval == 0 :
+        logger.info("Passed (datagram)")
+    else :
         logger.info("Failed {} checks, see above".format(str(retval)))
+        return retval
+
+    # --- Stream read pass ---
+    from olcbchecker.stream_utils import query_stream_support, read_via_stream
+    from openlcb.pip import PIP as PIP_enum
+
+    stream_ok = query_stream_support(destination)
+    if not stream_ok :
+        logger.info("Skipped (stream) - Config Options stream bit not set")
+        return 0
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is not None and PIP_enum.STREAM_PROTOCOL not in pipSet :
+            logger.info("Skipped (stream) - Stream protocol not in PIP")
+            return 0
+
+    try :
+        # Read entire FDI via stream (length=0 means read to end)
+        stream_data = read_via_stream(logger, destination, 0xFA, 0, 0)
+
+        # Compare stream data to datagram-read content
+        if list(stream_data[:len(content)]) != content :
+            logger.warning("Failure (stream) - FDI via stream does not match "
+                           "FDI via datagram ({} stream bytes vs {} "
+                           "datagram bytes)"
+                           .format(len(stream_data), len(content)))
+            return 3
+
+        logger.info("Passed (stream)")
+
+    except Exception as e :
+        logger.warning("Failure (stream) - {}".format(str(e)))
+        return 3
+
     return retval
 
 if __name__ == "__main__":

--- a/check_mc10_co.py
+++ b/check_mc10_co.py
@@ -126,7 +126,14 @@ def check():
     if (reply.data[4]&0xFE) != 0xE2 :
         logger.warning ("Failure - improper write bits set")
         return (3)
-    
+
+    # Log stream support status for visibility
+    stream_supported = bool(reply.data[4] & 0x01)
+    if stream_supported :
+        logger.info("Note - stream read/write supported (bit 0x01 set)")
+    else :
+        logger.info("Note - stream read/write not supported")
+
     logger.info("Passed")
     return 0
 

--- a/check_mc30_read.py
+++ b/check_mc30_read.py
@@ -163,12 +163,53 @@ def check():
         return reply
 
     reply = sendAndCheckResponse(destination, [0x20, 0x40, 0,0,0,0, 0xFD, 64], 64)
-    if reply != 0 : 
+    if reply != 0 :
         logger.warning("   in read of 64 bytes from long-form read")
         return reply
-        
-            
-    logger.info("Passed")
+
+    logger.info("Passed (datagram)")
+
+    # --- Stream read pass ---
+    from olcbchecker.stream_utils import query_stream_support, read_via_stream
+    from openlcb.pip import PIP as PIP_enum
+
+    stream_ok = query_stream_support(destination)
+    if not stream_ok :
+        logger.info("Skipped (stream) - Config Options stream bit not set")
+        return 0
+
+    # Also verify PIP says stream protocol is available
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is not None and PIP_enum.STREAM_PROTOCOL not in pipSet :
+            logger.info("Skipped (stream) - Stream protocol not in PIP")
+            return 0
+
+    # Read 10 bytes from space 0xFD via stream and compare to datagram read
+    try :
+        # First get reference data via datagram
+        ref_request = [0x20, 0x41, 0,0,0,0, 10]
+        message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, ref_request)
+        olcbchecker.sendMessage(message)
+        ref_reply = getReplyDatagram(destination)
+        ref_data = ref_reply.data[6:]  # skip header bytes
+
+        # Now read same data via stream
+        stream_data = read_via_stream(logger, destination, 0xFD, 0, 10)
+
+        # Compare
+        if list(stream_data[:10]) != list(ref_data[:10]) :
+            logger.warning("Failure (stream) - stream data does not match "
+                           "datagram data: stream={}, datagram={}"
+                           .format(stream_data[:10], list(ref_data[:10])))
+            return 3
+
+        logger.info("Passed (stream)")
+
+    except Exception as e :
+        logger.warning("Failure (stream) - {}".format(str(e)))
+        return 3
+
     return 0
 
 if __name__ == "__main__":

--- a/check_mc60_out_of_range.py
+++ b/check_mc60_out_of_range.py
@@ -283,7 +283,105 @@ def check():
 
             last_ping = time.time()
 
-    logger.info("Passed")
+    logger.info("Passed (datagram)")
+
+    # --- Stream error path ---
+    from olcbchecker.stream_utils import (query_stream_support,
+                                          build_read_stream_command)
+
+    stream_ok = query_stream_support(destination)
+    if not stream_ok :
+        logger.info("Skipped (stream) - Config Options stream bit not set")
+        return 0
+
+    from openlcb.pip import PIP as PIP_enum
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is not None and PIP_enum.STREAM_PROTOCOL not in pipSet :
+            logger.info("Skipped (stream) - Stream protocol not in PIP")
+            return 0
+
+    # Send Read Stream Command to out-of-range address
+    olcbchecker.purgeMessages()
+
+    payload = build_read_stream_command(0xFD, out_of_range, 64, 0xFF)
+    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()),
+                      destination, payload)
+    olcbchecker.sendMessage(message)
+
+    # Expect either:
+    # (a) Datagram Rejected -- node rejects at datagram level, or
+    # (b) Datagram OK followed by Read Stream Reply with Fail bit,
+    #     no stream opened
+    try :
+        while True :
+            try :
+                received = olcbchecker.getMessage(2.0)
+                if destination != received.source :
+                    continue
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+
+                if received.mti == MTI.Datagram_Rejected :
+                    # Path (a): acceptable
+                    logger.info("Note (stream) - node rejected Read Stream "
+                                "Command datagram for out-of-range address")
+                    break
+
+                if received.mti == MTI.Datagram_Received_OK :
+                    # Path (b): wait for Read Stream Reply with Fail
+                    while True :
+                        try :
+                            received = olcbchecker.getMessage(3.0)
+                            if received.mti != MTI.Datagram :
+                                # Could be Stream Initiate -- that would be
+                                # wrong for an out-of-range read
+                                if received.mti == MTI.Stream_Initiate_Request :
+                                    logger.warning(
+                                        "Failure (stream) - node opened "
+                                        "stream for out-of-range address")
+                                    return 3
+                                continue
+                            if destination != received.source :
+                                continue
+
+                            # ACK the reply datagram
+                            ack = Message(MTI.Datagram_Received_OK,
+                                          NodeID(olcbchecker.ownnodeid()),
+                                          destination, [0])
+                            olcbchecker.sendMessage(ack)
+
+                            # Verify Fail bit
+                            if len(received.data) >= 2 :
+                                cmd = received.data[1]
+                                if (cmd & 0x08) == 0 :
+                                    logger.warning(
+                                        "Failure (stream) - Read Stream "
+                                        "Reply for out-of-range address "
+                                        "did not have Fail bit set")
+                                    return 3
+                            break
+                        except Empty :
+                            logger.warning(
+                                "Failure (stream) - no Read Stream Reply "
+                                "after Datagram OK for out-of-range read")
+                            return 3
+                    break
+
+                continue
+
+            except Empty :
+                logger.warning(
+                    "Failure (stream) - no response to Read Stream "
+                    "Command for out-of-range address")
+                return 3
+
+        logger.info("Passed (stream)")
+
+    except Exception as e :
+        logger.warning("Failure (stream) - {}".format(str(e)))
+        return 3
+
     return 0
 
 if __name__ == "__main__":

--- a/check_mc80_write.py
+++ b/check_mc80_write.py
@@ -266,7 +266,69 @@ def check():
         logger.warning(str(e))
         return (3)
 
-    logger.info("Passed")
+    logger.info("Passed (datagram)")
+
+    # --- Stream write pass ---
+    from olcbchecker.stream_utils import query_stream_support, write_via_stream
+    from openlcb.pip import PIP as PIP_enum
+
+    stream_ok = query_stream_support(destination)
+    if not stream_ok :
+        logger.info("Skipped (stream) - Config Options stream bit not set")
+        return 0
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is not None and PIP_enum.STREAM_PROTOCOL not in pipSet :
+            logger.info("Skipped (stream) - Stream protocol not in PIP")
+            return 0
+
+    try :
+        # Read original value (for restore)
+        stream_original = readByte(destination, test_address, 0xFD)
+
+        # Compute test pattern
+        stream_test = (~stream_original) & 0xFF
+
+        # Write via stream
+        write_via_stream(logger, destination, 0xFD, test_address,
+                         [stream_test])
+
+        # Read back via datagram to verify
+        value = readByte(destination, test_address, 0xFD)
+        if value != stream_test :
+            logger.warning("Failure (stream) - write verify: wrote "
+                           "0x{:02X}, read back 0x{:02X}"
+                           .format(stream_test, value))
+            # Restore before failing
+            sendWriteDatagram(destination,
+                [0x20, 0x00, ad1, ad2, ad3, ad4, 0xFD, stream_original])
+            return 3
+
+        # Restore original value via datagram
+        sendWriteDatagram(destination,
+            [0x20, 0x00, ad1, ad2, ad3, ad4, 0xFD, stream_original])
+
+        # Verify restore
+        value = readByte(destination, test_address, 0xFD)
+        if value != stream_original :
+            logger.warning("Failure (stream) - restore verify: wrote "
+                           "0x{:02X}, read back 0x{:02X}"
+                           .format(stream_original, value))
+            return 3
+
+        logger.info("Passed (stream)")
+
+    except Exception as e :
+        # Best-effort restore
+        try :
+            sendWriteDatagram(destination,
+                [0x20, 0x00, ad1, ad2, ad3, ad4, 0xFD, original])
+        except Exception :
+            pass
+        logger.warning("Failure (stream) - {}".format(str(e)))
+        return 3
+
     return 0
 
 if __name__ == "__main__":

--- a/check_st100_concurrent_same_node.py
+++ b/check_st100_concurrent_same_node.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT can handle two concurrent streams from the
+same source node with different Source Stream IDs.
+
+Opens stream A (SID 0xA0) and stream B (SID 0xB0), sends data
+interleaved on both, and verifies each Proceed carries the correct
+SID/DID pair for its stream.
+
+Per StreamTransportTN section 1, a pair of nodes may maintain up to
+255 simultaneously open streams.  A DUT that rejects the second stream
+is spec-legal -- this test passes with info in that case.
+
+Usage:
+python3.10 check_st100_concurrent_same_node.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open stream A
+    sid_a = 0xA0
+    buf_a, did_a = _open_stream(logger, destination, 256, sid_a)
+
+    if buf_a is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test concurrent streams")
+        return 0
+
+    # Open stream B
+    sid_b = 0xB0
+    buf_b, did_b = _open_stream(logger, destination, 256, sid_b)
+
+    if buf_b is None :
+        _close_stream(destination, sid_a, did_a)
+        logger.info("Passed - node rejected second concurrent stream, "
+                     "spec-legal single-stream node")
+        return 0
+
+    # Two rounds of interleaved transfer
+    for round_num in range(1, 3) :
+
+        # Send buffer on stream A
+        _send_buffer(destination, did_a, buf_a,
+                     offset=((round_num - 1) * buf_a))
+        if not _wait_for_proceed(logger, destination, sid_a, did_a,
+                                 "A round {}".format(round_num)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+        # Send buffer on stream B
+        _send_buffer(destination, did_b, buf_b,
+                     offset=((round_num - 1) * buf_b))
+        if not _wait_for_proceed(logger, destination, sid_b, did_b,
+                                 "B round {}".format(round_num)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+    # Close both streams
+    _close_stream(destination, sid_a, did_a)
+    _close_stream(destination, sid_b, did_b)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st10_initiate.py
+++ b/check_st10_initiate.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a node responds to a Stream Initiate Request with
+either a valid Stream Initiate Reply or Optional Interaction Rejected.
+
+Per StreamTransportS section 7.1, the destination node is required to
+send a Stream Initiate Reply, or the general error message Optional
+Interaction Rejected.
+
+Usage:
+python3.10 check_st10_initiate.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    # check if PIP says this is present
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Send Stream Initiate Request
+    # Bytes 0-1: Max Buffer Size = 256 (0x0100)
+    # Bytes 2-3: Flags = 0x0000
+    # Byte 4: Source Stream ID = 0x01
+    data = [0x01, 0x00, 0x00, 0x00, 0x01]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    sid = 0x01
+    did = None
+    stream_accepted = False
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                if destination != received.source :
+                    continue
+                logger.info("Passed - node responded with Optional "
+                            "Interaction Rejected")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if destination != received.source :
+                    continue
+
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    logger.warning("Failure - Unexpected destination of "
+                                   "reply: {}".format(received.destination))
+                    return(3)
+
+                if len(received.data) < 6 :
+                    logger.warning("Failure - Stream Initiate Reply too "
+                                   "short: {} bytes".format(
+                                       len(received.data)))
+                    return(3)
+
+                # Check SID echoed back
+                if received.data[4] != sid :
+                    logger.warning("Failure - Source Stream ID not echoed: "
+                                   "sent 0x{:02X}, got 0x{:02X}".format(
+                                       sid, received.data[4]))
+                    return(3)
+
+                # Check DID not reserved
+                did = received.data[5]
+                if did == 0xFF :
+                    logger.warning("Failure - Destination Stream ID is "
+                                   "reserved value 0xFF")
+                    return(3)
+
+                # Check flags
+                flags = (received.data[2] << 8) | received.data[3]
+                buf_size = (received.data[0] << 8) | received.data[1]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted
+                    if buf_size == 0 :
+                        logger.warning("Failure - accepted but buffer "
+                                       "size is 0")
+                        return(3)
+                    if buf_size > 256 :
+                        logger.warning("Failure - reply buffer size {} "
+                                       "exceeds requested 256".format(
+                                           buf_size))
+                        return(3)
+                    stream_accepted = True
+                elif (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    # rejected with valid error code
+                    if buf_size != 0 :
+                        logger.warning("Failure - rejected but buffer "
+                                       "size is non-zero: {}".format(
+                                           buf_size))
+                        return(3)
+                else :
+                    logger.warning("Failure - invalid flags in reply: "
+                                   "0x{:04X}".format(flags))
+                    return(3)
+
+                break
+
+            # ignore other messages
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request")
+            return(3)
+
+    # If stream was accepted, close it cleanly
+    if stream_accepted :
+        complete_data = [sid, did]
+        message = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          complete_data)
+        olcbchecker.sendMessage(message)
+        time.sleep(0.5)
+
+    # Stability soak
+    timeout = 30
+    ping_interval = 10
+    last_ping = 0
+    logger.info("Stability soak: monitoring node for {} seconds".format(
+        timeout))
+    start = time.time()
+
+    while time.time() - start < timeout :
+        try :
+            received = olcbchecker.getMessage(1)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted after stream "
+                               "initiation")
+                return(3)
+
+        except Empty:
+            pass
+
+        if time.time() - last_ping >= ping_interval :
+            elapsed = int(time.time() - start)
+            logger.info("  soak {}/{}s - pinging node...".format(
+                elapsed, timeout))
+            olcbchecker.purgeMessages()
+            message = Message(MTI.Verify_NodeID_Number_Addressed,
+                              NodeID(olcbchecker.ownnodeid()), destination)
+            olcbchecker.sendMessage(message)
+
+            alive = False
+            while True :
+                try :
+                    received = olcbchecker.getMessage()
+                    if received.mti != MTI.Verified_NodeID and \
+                            received.mti != MTI.Verified_NodeID_Simple :
+                        continue
+                    if destination != received.source :
+                        continue
+                    alive = True
+                    break
+                except Empty:
+                    break
+
+            if not alive :
+                logger.warning("Failure - node stopped responding after "
+                               "stream initiation")
+                return(3)
+
+            last_ping = time.time()
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st110_concurrent_multi_node.py
+++ b/check_st110_concurrent_multi_node.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT can handle concurrent streams from two
+different source nodes.
+
+The checker claims a second CAN alias to act as a spoofed source node,
+then opens one stream from its real identity and one from the spoofed
+alias.  Verifies the DUT tracks them independently by source node.
+
+Per StreamTransportTN section 2.3.1, a stream is uniquely identified by
+(Source Node ID, Destination Node ID, Source Stream ID).  SID by itself
+need not be unique -- the same SID from two different source nodes
+identifies two distinct streams.
+
+A DUT that rejects either stream is spec-legal -- this test passes with
+info in that case.
+
+Usage:
+python3.10 check_st110_concurrent_multi_node.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+from openlcb.canbus.canframe import CanFrame
+from openlcb.canbus.controlframe import ControlFrame
+
+from queue import Empty
+
+
+# Spoofed node identity -- fabricated, must not collide with real nodes
+_SPOOFED_NODE_ID = "06.02.00.00.01.99"
+_SPOOFED_ALIAS = 0x299
+
+
+# =========================================================================
+# Helpers for the real checker node (message-level API)
+# =========================================================================
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+# =========================================================================
+# Helpers for the spoofed node (raw CAN frame API)
+# =========================================================================
+
+def _claim_spoofed_alias(logger):
+    '''Claim a CAN alias for the spoofed node via CID/RID/AMD.'''
+    import olcbchecker
+    node_id = NodeID(_SPOOFED_NODE_ID)
+
+    # Send CID 7, 6, 5, 4
+    for n in [7, 6, 5, 4] :
+        frame = CanFrame(n, node_id, _SPOOFED_ALIAS)
+        olcbchecker.setup.sendCanFrame(frame)
+
+    # Wait for any RID collision response (200ms per CAN spec)
+    time.sleep(0.2)
+
+    # Send RID to reserve the alias
+    frame = CanFrame(ControlFrame.RID.value, _SPOOFED_ALIAS, [])
+    olcbchecker.setup.sendCanFrame(frame)
+
+    # Send AMD to announce the alias mapping
+    frame = CanFrame(ControlFrame.AMD.value, _SPOOFED_ALIAS,
+                     node_id.toArray())
+    olcbchecker.setup.sendCanFrame(frame)
+
+    time.sleep(0.1)
+    return True
+
+
+def _release_spoofed_alias():
+    '''Release the spoofed alias via AMR.'''
+    import olcbchecker
+    node_id = NodeID(_SPOOFED_NODE_ID)
+    frame = CanFrame(ControlFrame.AMR.value, _SPOOFED_ALIAS,
+                     node_id.toArray())
+    olcbchecker.setup.sendCanFrame(frame)
+    time.sleep(0.1)
+
+
+def _get_dest_alias(destination):
+    '''Look up the CAN alias for the destination node.'''
+    import olcbchecker
+    alias = olcbchecker.setup.canLink.nodeIdToAlias.get(destination)
+    return alias
+
+
+def _spoofed_open_stream(logger, dest_alias, proposed_size, sid):
+    '''Open a stream from the spoofed node via raw CAN frames.
+
+    Returns (buf_size, did) or (None, None).
+    '''
+    import olcbchecker
+
+    # Build Stream Initiate Request as addressed CAN frame
+    # Header: Frame Type 1, MTI 0x0CC8 -> field 0xCC8, source = spoofed alias
+    header = 0x19_CC8_000 | (_SPOOFED_ALIAS & 0xFFF)
+
+    # Data: [dest_alias_hi, dest_alias_lo, buf_hi, buf_lo, 0x00, 0x00, sid]
+    dest_hi = (dest_alias >> 8) & 0x0F
+    dest_lo = dest_alias & 0xFF
+    data = [dest_hi, dest_lo,
+            (proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+
+    frame = CanFrame(header, data)
+    olcbchecker.setup.sendCanFrame(frame)
+
+    # Read reply from frame queue (not message queue)
+    while True :
+        try :
+            reply = olcbchecker.getFrame(2.0)
+
+            # Extract MTI field from header bits [23:12]
+            mti_field = (reply.header >> 12) & 0xFFF
+
+            # Stream Initiate Reply: MTI 0x0868 -> field 0x868
+            if mti_field == 0x868 :
+                if len(reply.data) < 2 :
+                    continue
+                # Check destination alias matches spoofed node
+                frame_dest = ((reply.data[0] & 0x0F) << 8) | reply.data[1]
+                if frame_dest != _SPOOFED_ALIAS :
+                    continue
+                # Payload starts at data[2]
+                payload = reply.data[2:]
+                if len(payload) < 6 :
+                    return (None, None)
+                buf_size = (payload[0] << 8) | payload[1]
+                flags = (payload[2] << 8) | payload[3]
+                did = payload[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+
+            # Optional Interaction Rejected: MTI 0x0068 -> field 0x068
+            if mti_field == 0x068 :
+                if len(reply.data) >= 2 :
+                    frame_dest = ((reply.data[0] & 0x0F) << 8) | reply.data[1]
+                    if frame_dest == _SPOOFED_ALIAS :
+                        return (None, None)
+
+            continue
+
+        except Empty:
+            return (None, None)
+
+
+def _spoofed_send_buffer(dest_alias, did, buf_size, offset=0):
+    '''Send stream data from the spoofed node via raw CAN Frame Type 7.'''
+    import olcbchecker
+
+    # Frame Type 7: header 0x1F_DDD_SSS
+    header = 0x1F_000_000 | ((dest_alias & 0xFFF) << 12) | \
+             (_SPOOFED_ALIAS & 0xFFF)
+
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 7)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        frame = CanFrame(header, data)
+        olcbchecker.setup.sendCanFrame(frame)
+        bytes_sent += chunk_size
+
+
+def _spoofed_wait_for_proceed(logger, sid, did, label):
+    '''Wait for Stream Data Proceed addressed to spoofed node.
+
+    Reads from frame queue. Returns True on success.
+    '''
+    import olcbchecker
+
+    while True :
+        try :
+            reply = olcbchecker.getFrame(3.0)
+
+            mti_field = (reply.header >> 12) & 0xFFF
+
+            # Stream Data Proceed: MTI 0x0888 -> field 0x888
+            if mti_field == 0x888 :
+                if len(reply.data) < 4 :
+                    continue
+                frame_dest = ((reply.data[0] & 0x0F) << 8) | reply.data[1]
+                if frame_dest != _SPOOFED_ALIAS :
+                    continue
+                # Payload: data[2] = SID, data[3] = DID
+                if reply.data[2] != sid :
+                    logger.warning("Failure - spoofed Proceed SID mismatch "
+                                   "({}): expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, reply.data[2]))
+                    return False
+                if reply.data[3] != did :
+                    logger.warning("Failure - spoofed Proceed DID mismatch "
+                                   "({}): expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, reply.data[3]))
+                    return False
+                return True
+
+            # Terminate Due To Error: MTI 0x00A8 -> field 0x0A8
+            if mti_field == 0x0A8 :
+                if len(reply.data) >= 2 :
+                    frame_dest = ((reply.data[0] & 0x0F) << 8) | reply.data[1]
+                    if frame_dest == _SPOOFED_ALIAS :
+                        logger.warning("Failure - Terminate on spoofed "
+                                       "stream ({})".format(label))
+                        return False
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no spoofed Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _spoofed_close_stream(dest_alias, sid, did):
+    '''Close a stream from the spoofed node via raw CAN frame.'''
+    import olcbchecker
+
+    # Stream Data Complete: MTI 0x08A8 -> field 0x8A8
+    header = 0x19_8A8_000 | (_SPOOFED_ALIAS & 0xFFF)
+    dest_hi = (dest_alias >> 8) & 0x0F
+    dest_lo = dest_alias & 0xFF
+    data = [dest_hi, dest_lo, sid, did]
+    frame = CanFrame(header, data)
+    olcbchecker.setup.sendCanFrame(frame)
+    time.sleep(0.3)
+
+
+# =========================================================================
+# Main check
+# =========================================================================
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Get destination alias for raw frame construction
+    dest_alias = _get_dest_alias(destination)
+    if dest_alias is None :
+        logger.warning("Failed in setup, could not resolve destination alias")
+        return (2)
+
+    # Open stream A from real checker node
+    sid_a = 0x6E
+    buf_a, did_a = _open_stream(logger, destination, 256, sid_a)
+
+    if buf_a is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test multi-node concurrent streams")
+        return 0
+
+    # Claim spoofed alias
+    _claim_spoofed_alias(logger)
+
+    # Purge frames generated by alias claiming
+    olcbchecker.purgeFrames()
+    olcbchecker.purgeMessages()
+
+    # Open stream B from spoofed node (same SID is legal -- different source)
+    sid_b = 0x01
+    buf_b, did_b = _spoofed_open_stream(logger, dest_alias, 256, sid_b)
+
+    if buf_b is None :
+        _close_stream(destination, sid_a, did_a)
+        _release_spoofed_alias()
+        logger.info("Passed - node rejected stream from second source, "
+                     "spec-legal")
+        return 0
+
+    # One round of interleaved transfer
+
+    # Stream A (real node, message-level)
+    _send_buffer(destination, did_a, buf_a, offset=0)
+    if not _wait_for_proceed(logger, destination, sid_a, did_a,
+                             "real node") :
+        _close_stream(destination, sid_a, did_a)
+        _spoofed_close_stream(dest_alias, sid_b, did_b)
+        _release_spoofed_alias()
+        return(3)
+
+    # Stream B (spoofed node, raw CAN frames)
+    _spoofed_send_buffer(dest_alias, did_b, buf_b, offset=0)
+    if not _spoofed_wait_for_proceed(logger, sid_b, did_b,
+                                     "spoofed node") :
+        _close_stream(destination, sid_a, did_a)
+        _spoofed_close_stream(dest_alias, sid_b, did_b)
+        _release_spoofed_alias()
+        return(3)
+
+    # Close both streams
+    _close_stream(destination, sid_a, did_a)
+    _spoofed_close_stream(dest_alias, sid_b, did_b)
+
+    # Release spoofed alias
+    _release_spoofed_alias()
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st120_sustained_transfer.py
+++ b/check_st120_sustained_transfer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3.10
+'''
+This checks sustained high-throughput stream transfer with zero delay
+between buffer cycles.
+
+Opens a stream and runs 22 consecutive send/proceed cycles back-to-back.
+Verifies the DUT does not leak memory, lose window count, or stall over
+many consecutive cycles.  After the transfer, reopens a stream to confirm
+the DUT is not stuck.
+
+Per StreamTransportTN section 1, a node may support up to 255 concurrent
+streams, and sustained transfer must not degrade.
+
+Usage:
+python3.10 check_st120_sustained_transfer.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, cycle_num):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error in "
+                               "cycle {}".format(cycle_num))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed in cycle {}"
+                           .format(cycle_num))
+            return False
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0x78
+    buf_size, did = _open_stream(logger, destination, 256, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test sustained transfer")
+        return 0
+
+    # Run 22 consecutive send/proceed cycles with zero delay
+    cycle_count = 22
+    for cycle in range(1, cycle_count + 1) :
+        _send_buffer(destination, did, buf_size,
+                     offset=((cycle - 1) * buf_size))
+        if not _wait_for_proceed(logger, destination, sid, did, cycle) :
+            complete = Message(MTI.Stream_Data_Complete,
+                              NodeID(olcbchecker.ownnodeid()), destination,
+                              [sid, did])
+            olcbchecker.sendMessage(complete)
+            time.sleep(0.3)
+            return(3)
+
+    # Close the stream
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    # Stability probe: reopen a stream to confirm DUT is not stuck
+    olcbchecker.purgeMessages()
+    probe_sid = 0x79
+    probe_buf, probe_did = _open_stream(logger, destination, 256, probe_sid)
+    if probe_buf is not None :
+        probe_complete = Message(MTI.Stream_Data_Complete,
+                                NodeID(olcbchecker.ownnodeid()), destination,
+                                [probe_sid, probe_did])
+        olcbchecker.sendMessage(probe_complete)
+        time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st130_min_chunk_send.py
+++ b/check_st130_min_chunk_send.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT handles the maximum number of CAN frames per
+buffer window by sending each payload byte as a separate Stream Data
+Send message.
+
+Opens a stream with a small buffer (64 bytes) and sends buf_size
+individual 1-byte-payload messages per cycle.  This stresses the
+receive path and any internal frame-to-stream reassembly.
+
+Usage:
+python3.10 check_st130_min_chunk_send.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_single_byte_frames(destination, did, buf_size, offset=0):
+    '''Send buf_size bytes, each as a separate Stream Data Send message.'''
+    import olcbchecker
+    for i in range(buf_size) :
+        data = [did, (offset + i) & 0xFF]
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+
+
+def _wait_for_proceed(logger, destination, sid, did, cycle_num):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(5.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error in "
+                               "cycle {}".format(cycle_num))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed in cycle {}"
+                           .format(cycle_num))
+            return False
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0x82
+    buf_size, did = _open_stream(logger, destination, 64, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test minimum chunk send")
+        return 0
+
+    # Cycle 1: send buf_size individual 1-byte frames
+    _send_single_byte_frames(destination, did, buf_size, offset=0)
+    if not _wait_for_proceed(logger, destination, sid, did, 1) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Cycle 2: confirm stability with another round
+    _send_single_byte_frames(destination, did, buf_size, offset=buf_size)
+    if not _wait_for_proceed(logger, destination, sid, did, 2) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Close the stream
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st140_concurrent_sustained.py
+++ b/check_st140_concurrent_sustained.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3.10
+'''
+This checks sustained transfer on two concurrent streams simultaneously.
+
+Opens two streams and runs 10 interleaved send/proceed cycles on both.
+Stresses total buffer pool allocation, not just per-stream buffers.
+After completion, reopens a single stream to verify the DUT recovered.
+
+Per StreamTransportTN section 1, a pair of nodes may maintain up to
+255 simultaneously open streams.  A DUT that rejects the second stream
+is spec-legal -- this test passes with info in that case.
+
+Usage:
+python3.10 check_st140_concurrent_sustained.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open stream A
+    sid_a = 0x8C
+    buf_a, did_a = _open_stream(logger, destination, 256, sid_a)
+
+    if buf_a is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test concurrent sustained transfer")
+        return 0
+
+    # Open stream B
+    sid_b = 0x8D
+    buf_b, did_b = _open_stream(logger, destination, 256, sid_b)
+
+    if buf_b is None :
+        _close_stream(destination, sid_a, did_a)
+        logger.info("Passed - node rejected second concurrent stream, "
+                     "spec-legal single-stream node")
+        return 0
+
+    # 10 interleaved send/proceed cycles
+    cycle_count = 10
+    for cycle in range(1, cycle_count + 1) :
+
+        # Stream A
+        _send_buffer(destination, did_a, buf_a,
+                     offset=((cycle - 1) * buf_a))
+        if not _wait_for_proceed(logger, destination, sid_a, did_a,
+                                 "A cycle {}".format(cycle)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+        # Stream B
+        _send_buffer(destination, did_b, buf_b,
+                     offset=((cycle - 1) * buf_b))
+        if not _wait_for_proceed(logger, destination, sid_b, did_b,
+                                 "B cycle {}".format(cycle)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+    # Close both streams
+    _close_stream(destination, sid_a, did_a)
+    _close_stream(destination, sid_b, did_b)
+
+    # Stability probe: reopen a single stream to verify recovery
+    olcbchecker.purgeMessages()
+    probe_sid = 0x8E
+    probe_buf, probe_did = _open_stream(logger, destination, 256, probe_sid)
+    if probe_buf is not None :
+        probe_complete = Message(MTI.Stream_Data_Complete,
+                                NodeID(olcbchecker.ownnodeid()), destination,
+                                [probe_sid, probe_did])
+        olcbchecker.sendMessage(probe_complete)
+        time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st150_asymmetric_buffers.py
+++ b/check_st150_asymmetric_buffers.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT correctly tracks different negotiated buffer
+sizes on two concurrent streams.
+
+Opens stream A with proposed buffer 64 and stream B with proposed
+buffer 1024.  The DUT must send Proceed at the right boundary for each
+stream independently based on each stream's negotiated size.
+
+Per StreamTransportTN section 2.3.1, each stream is uniquely identified
+by (Source Node ID, Destination Node ID, Source Stream ID) and
+maintains its own Max Buffer Size.
+
+Usage:
+python3.10 check_st150_asymmetric_buffers.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open stream A with small buffer
+    sid_a = 0x96
+    buf_a, did_a = _open_stream(logger, destination, 64, sid_a)
+
+    if buf_a is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test asymmetric buffers")
+        return 0
+
+    # Open stream B with large buffer
+    sid_b = 0x97
+    buf_b, did_b = _open_stream(logger, destination, 1024, sid_b)
+
+    if buf_b is None :
+        _close_stream(destination, sid_a, did_a)
+        logger.info("Passed - node rejected second concurrent stream, "
+                     "spec-legal single-stream node")
+        return 0
+
+    logger.info("  Stream A negotiated buf_size = {}".format(buf_a))
+    logger.info("  Stream B negotiated buf_size = {}".format(buf_b))
+
+    # Two rounds of interleaved transfer
+    for round_num in range(1, 3) :
+
+        # Send on stream A (small buffer)
+        _send_buffer(destination, did_a, buf_a,
+                     offset=((round_num - 1) * buf_a))
+        if not _wait_for_proceed(logger, destination, sid_a, did_a,
+                                 "A round {}".format(round_num)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+        # Send on stream B (large buffer)
+        _send_buffer(destination, did_b, buf_b,
+                     offset=((round_num - 1) * buf_b))
+        if not _wait_for_proceed(logger, destination, sid_b, did_b,
+                                 "B round {}".format(round_num)) :
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+    # Close both streams
+    _close_stream(destination, sid_a, did_a)
+    _close_stream(destination, sid_b, did_b)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st155_negotiation_enforcement.py
+++ b/check_st155_negotiation_enforcement.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT sends Stream Data Proceed based on its own
+negotiated buffer size, not the proposed size.
+
+The checker proposes a large buffer (1024).  The DUT may negotiate down
+to a smaller value.  The test sends exactly the negotiated amount and
+verifies Proceed arrives at the right boundary.
+
+Per StreamTransportS section 7.1, the Max Buffer Size in the reply is
+the final negotiated value for flow control.
+
+Usage:
+python3.10 check_st155_negotiation_enforcement.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, cycle_num):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error in "
+                               "cycle {}".format(cycle_num))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed in cycle {}"
+                           .format(cycle_num))
+            return False
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Propose a large buffer -- DUT may negotiate down
+    proposed = 1024
+    sid = 0x55
+    buf_size, did = _open_stream(logger, destination, proposed, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test negotiation enforcement")
+        return 0
+
+    if buf_size < proposed :
+        logger.info("  DUT negotiated buffer down from {} to {}"
+                     .format(proposed, buf_size))
+    else :
+        logger.info("  DUT accepted proposed buffer size {}"
+                     .format(buf_size))
+
+    # Cycle 1: send exactly the negotiated buf_size
+    _send_buffer(destination, did, buf_size, offset=0)
+    if not _wait_for_proceed(logger, destination, sid, did, 1) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Cycle 2: confirm consistency
+    _send_buffer(destination, did, buf_size, offset=buf_size)
+    if not _wait_for_proceed(logger, destination, sid, did, 2) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Close the stream
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st170_zero_payload_flush.py
+++ b/check_st170_zero_payload_flush.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT handles a zero-payload Stream Data Send (flush)
+correctly during an active transfer.
+
+Per StreamTransportS Section 6.3: "A Stream Data Send message may also
+contain zero payload bytes. This is considered a flush, and should result
+in the destination node (and any gateways in between) flushing any
+internal buffering for efficiency that may be occurring."
+
+The test sends half the buffer window, then a zero-payload flush, then
+the remaining half. The DUT must not crash, not send an error, and must
+send Proceed at the correct byte boundary (the flush does not count
+toward the buffer window).
+
+Usage:
+python3.10 check_st170_zero_payload_flush.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_data(destination, did, payload_bytes):
+    '''Send a chunk of stream data with the given payload bytes.'''
+    import olcbchecker
+    data = [did] + payload_bytes
+    message = Message(MTI.Stream_Data_Send,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+
+def _send_flush(destination, did):
+    '''Send a zero-payload Stream Data Send (flush).'''
+    import olcbchecker
+    data = [did]
+    message = Message(MTI.Stream_Data_Send,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+
+def _send_bytes(destination, did, count, offset=0):
+    '''Send count payload bytes in chunks of up to 64.'''
+    bytes_sent = 0
+    while bytes_sent < count :
+        chunk_size = min(count - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        _send_data(destination, did, payload)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0xD0
+    buf_size, did = _open_stream(logger, destination, 256, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test zero-payload flush")
+        return 0
+
+    # Two cycles: send half, flush, send other half, wait for Proceed
+    for cycle in range(1, 3) :
+
+        half = buf_size // 2
+        remainder = buf_size - half
+        offset = (cycle - 1) * buf_size
+
+        # Send first half of the buffer window
+        _send_bytes(destination, did, half, offset=offset)
+
+        # Send zero-payload flush
+        _send_flush(destination, did)
+
+        # Send remaining half to complete the window
+        _send_bytes(destination, did, remainder, offset=(offset + half))
+
+        # Wait for Proceed -- must arrive after full buf_size payload bytes
+        if not _wait_for_proceed(logger, destination, sid, did,
+                                 "cycle {}".format(cycle)) :
+            _close_stream(destination, sid, did)
+            return(3)
+
+    _close_stream(destination, sid, did)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st180_interleaved_data_send.py
+++ b/check_st180_interleaved_data_send.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT correctly handles interleaved Stream Data Send
+messages on two concurrent streams within the same buffer window.
+
+Existing concurrent tests (st100, st110) send a full buffer on stream A,
+wait for Proceed, then send a full buffer on stream B. This test
+alternates 32-byte chunks between streams A and B before either window
+completes, forcing the DUT to track each stream's byte count
+independently.
+
+Per StreamTransportS Section 7.2: "If the node receives multiple
+overlapping [streams] from different source nodes, the states shall be
+independent." This extends to interleaved data within the same source
+when multiple SIDs are in use.
+
+A DUT that rejects the second stream is spec-legal -- this test passes
+with info in that case.
+
+Usage:
+python3.10 check_st180_interleaved_data_send.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_chunk(destination, did, count, offset=0):
+    '''Send exactly count payload bytes as a single Stream Data Send.'''
+    import olcbchecker
+    payload = [((offset + i) & 0xFF) for i in range(count)]
+    data = [did] + payload
+    message = Message(MTI.Stream_Data_Send,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, sid, received.data[0]))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({}): "
+                                   "expected 0x{:02X} got 0x{:02X}"
+                                   .format(label, did, received.data[1]))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})"
+                           .format(label))
+            return False
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def _interleaved_send(destination, did_a, buf_a, did_b, buf_b,
+                      chunk_size, cycle_offset):
+    '''Send interleaved chunks on two streams until both windows are full.
+
+    Alternates: chunk on A, chunk on B, chunk on A, chunk on B, ...
+    Each stream gets exactly its buf_size bytes total.
+    '''
+    sent_a = 0
+    sent_b = 0
+
+    while sent_a < buf_a or sent_b < buf_b :
+
+        # Send a chunk on stream A if it still has bytes to send
+        if sent_a < buf_a :
+            n = min(chunk_size, buf_a - sent_a)
+            _send_chunk(destination, did_a, n,
+                        offset=(cycle_offset + sent_a))
+            sent_a += n
+
+        # Send a chunk on stream B if it still has bytes to send
+        if sent_b < buf_b :
+            n = min(chunk_size, buf_b - sent_b)
+            _send_chunk(destination, did_b, n,
+                        offset=(cycle_offset + sent_b))
+            sent_b += n
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open stream A
+    sid_a = 0xE0
+    buf_a, did_a = _open_stream(logger, destination, 256, sid_a)
+
+    if buf_a is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test interleaved data send")
+        return 0
+
+    # Open stream B
+    sid_b = 0xE1
+    buf_b, did_b = _open_stream(logger, destination, 256, sid_b)
+
+    if buf_b is None :
+        _close_stream(destination, sid_a, did_a)
+        logger.info("Passed - node rejected second concurrent stream, "
+                     "spec-legal single-stream node")
+        return 0
+
+    # Two cycles of interleaved transfer
+    chunk_size = 32
+
+    for cycle in range(1, 3) :
+
+        cycle_offset = (cycle - 1) * max(buf_a, buf_b)
+
+        # Send interleaved chunks: A, B, A, B, ... until both full
+        _interleaved_send(destination, did_a, buf_a, did_b, buf_b,
+                          chunk_size, cycle_offset)
+
+        # Both windows are now full -- collect Proceeds for both streams.
+        # They may arrive in either order.
+        got_a = False
+        got_b = False
+
+        for _ in range(2) :
+
+            import olcbchecker
+            deadline = time.time() + 3.0
+
+            while time.time() < deadline :
+                remaining = deadline - time.time()
+                if remaining <= 0 :
+                    break
+                try :
+                    received = olcbchecker.getMessage(remaining)
+                    if destination != received.source :
+                        continue
+
+                    if received.mti == MTI.Terminate_Due_To_Error :
+                        logger.warning("Failure - Terminate Due To Error "
+                                       "(cycle {})".format(cycle))
+                        _close_stream(destination, sid_a, did_a)
+                        _close_stream(destination, sid_b, did_b)
+                        return(3)
+
+                    if received.mti != MTI.Stream_Data_Proceed :
+                        continue
+
+                    if len(received.data) < 2 :
+                        logger.warning("Failure - Proceed too short "
+                                       "(cycle {})".format(cycle))
+                        _close_stream(destination, sid_a, did_a)
+                        _close_stream(destination, sid_b, did_b)
+                        return(3)
+
+                    rsid = received.data[0]
+                    rdid = received.data[1]
+
+                    if rsid == sid_a and rdid == did_a and not got_a :
+                        got_a = True
+                        break
+                    elif rsid == sid_b and rdid == did_b and not got_b :
+                        got_b = True
+                        break
+                    else :
+                        logger.warning("Failure - unexpected Proceed "
+                                       "SID=0x{:02X} DID=0x{:02X} "
+                                       "(cycle {})".format(rsid, rdid, cycle))
+                        _close_stream(destination, sid_a, did_a)
+                        _close_stream(destination, sid_b, did_b)
+                        return(3)
+
+                except Empty:
+                    break
+
+        if not got_a :
+            logger.warning("Failure - no Proceed for stream A "
+                           "(cycle {})".format(cycle))
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+        if not got_b :
+            logger.warning("Failure - no Proceed for stream B "
+                           "(cycle {})".format(cycle))
+            _close_stream(destination, sid_a, did_a)
+            _close_stream(destination, sid_b, did_b)
+            return(3)
+
+    # Close both streams
+    _close_stream(destination, sid_a, did_a)
+    _close_stream(destination, sid_b, did_b)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st190_suggested_did.py
+++ b/check_st190_suggested_did.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a node handles a suggested Destination Stream ID in
+the Stream Initiate Request.
+
+Per StreamTransportS section 4.1, byte 0 of the Initiate Request may
+contain a suggested DID (0x00-0xFE) or 0xFF (no suggestion).  The DUT
+may use the suggested value or assign its own.
+
+Sequence:
+1. PIP guard
+2. Send Initiate Request with suggested DID = 0x42
+3. Verify reply: DID in range 0x00-0xFE, SID echoed
+4. If DUT used 0x42, log it; if it picked another, that is also valid
+5. Close stream, reopen with DID = 0xFF (no suggestion) to confirm
+   both paths work
+
+Usage:
+python3.10 check_st190_suggested_did.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream_with_did(logger, destination, proposed_size, sid,
+                          suggested_did):
+    '''Open a stream with a specific suggested DID byte.
+    Returns (buf_size, did, flags) or (None, None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid, suggested_did]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did, flags)
+                else :
+                    return (None, None, None)
+            continue
+        except Empty:
+            return (None, None, None)
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Test 1: suggest DID = 0x42
+    sid1 = 0x90
+    suggested = 0x42
+    buf_size, did, flags = _open_stream_with_did(
+        logger, destination, 256, sid1, suggested)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test suggested DID")
+        return 0
+
+    if did == 0xFF :
+        logger.warning("Failure - DID is reserved value 0xFF")
+        return(3)
+
+    if did == suggested :
+        logger.info("  node honored suggested DID 0x{:02X}".format(
+            suggested))
+    else :
+        logger.info("  node assigned DID 0x{:02X} instead of suggested "
+                     "0x{:02X} (valid)".format(did, suggested))
+
+    _close_stream(destination, sid1, did)
+
+    # Test 2: no suggestion (0xFF) to confirm both paths work
+    olcbchecker.purgeMessages()
+    sid2 = 0x91
+    buf_size2, did2, flags2 = _open_stream_with_did(
+        logger, destination, 256, sid2, 0xFF)
+
+    if buf_size2 is None :
+        logger.warning("Failure - node rejected stream with DID 0xFF "
+                       "after accepting suggested DID")
+        return(3)
+
+    if did2 == 0xFF :
+        logger.warning("Failure - DID is reserved value 0xFF")
+        return(3)
+
+    logger.info("  no-suggestion path assigned DID 0x{:02X}".format(did2))
+
+    _close_stream(destination, sid2, did2)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st200_complete_with_byte_count.py
+++ b/check_st200_complete_with_byte_count.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a node handles Stream Data Complete with the optional
+4-byte total byte count.
+
+Per StreamTransportS section 6.4, Stream Data Complete may optionally
+include a 4-byte count of total payload bytes transferred.  The DUT
+must handle both forms (with and without the count) without error.
+
+Sequence:
+1. PIP guard
+2. Open stream, send one full buffer, wait for Proceed
+3. Send Stream Data Complete WITH 4-byte byte count
+4. Verify no errors, reopen to confirm resources freed
+5. Open stream, send one full buffer, wait for Proceed
+6. Send Stream Data Complete WITHOUT byte count (2 bytes only)
+7. Verify no errors, reopen to confirm resources freed
+
+Usage:
+python3.10 check_st200_complete_with_byte_count.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, label):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short ({})"
+                                   .format(label))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch ({})"
+                                   .format(label))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch ({})"
+                                   .format(label))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error ({})"
+                               .format(label))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed ({})".format(label))
+            return False
+
+
+def _check_no_errors(logger, destination, label):
+    '''Drain messages and check for errors. Returns True if clean.'''
+    import olcbchecker
+    time.sleep(0.5)
+    while True :
+        try :
+            received = olcbchecker.getMessage(0.5)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error after "
+                               "Complete ({})".format(label))
+                return False
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted after "
+                               "Complete ({})".format(label))
+                return False
+        except Empty:
+            break
+    return True
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # --- Test 1: Complete WITH 4-byte byte count ---
+    sid1 = 0xC0
+    buf_size, did1 = _open_stream(logger, destination, 256, sid1)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test Complete with byte count")
+        return 0
+
+    _send_buffer(destination, did1, buf_size)
+
+    if not _wait_for_proceed(logger, destination, sid1, did1,
+                             "with-count") :
+        return(3)
+
+    # Stream Data Complete with byte count: [SID, DID, count(4 bytes BE)]
+    total = buf_size
+    complete_data = [sid1, did1,
+                     (total >> 24) & 0xFF,
+                     (total >> 16) & 0xFF,
+                     (total >> 8) & 0xFF,
+                     total & 0xFF]
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      complete_data)
+    olcbchecker.sendMessage(message)
+
+    if not _check_no_errors(logger, destination, "with-count") :
+        return(3)
+
+    logger.info("  Complete with 4-byte count accepted")
+
+    # Verify resources freed by reopening
+    olcbchecker.purgeMessages()
+    buf_size_r, did_r = _open_stream(logger, destination, 256, sid1)
+
+    if buf_size_r is None :
+        logger.warning("Failure - could not reopen after Complete "
+                       "with byte count")
+        return(3)
+
+    # Close the reopen check stream (2-byte form, no count)
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid1, did_r])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+    # --- Test 2: Complete WITHOUT byte count (2 bytes only) ---
+    olcbchecker.purgeMessages()
+    sid2 = 0xC1
+    buf_size2, did2 = _open_stream(logger, destination, 256, sid2)
+
+    if buf_size2 is None :
+        logger.warning("Failure - node rejected second stream open "
+                       "after first close")
+        return(3)
+
+    _send_buffer(destination, did2, buf_size2)
+
+    if not _wait_for_proceed(logger, destination, sid2, did2,
+                             "without-count") :
+        return(3)
+
+    # Stream Data Complete without byte count: [SID, DID] only
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid2, did2])
+    olcbchecker.sendMessage(message)
+
+    if not _check_no_errors(logger, destination, "without-count") :
+        return(3)
+
+    logger.info("  Complete without byte count accepted")
+
+    # Verify resources freed
+    olcbchecker.purgeMessages()
+    buf_size_r2, did_r2 = _open_stream(logger, destination, 256, sid2)
+
+    if buf_size_r2 is None :
+        logger.warning("Failure - could not reopen after Complete "
+                       "without byte count")
+        return(3)
+
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid2, did_r2])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st20_reject_unsupported.py
+++ b/check_st20_reject_unsupported.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a node which does NOT advertise Stream Protocol in PIP
+properly rejects a Stream Initiate Request with either OIR or a Stream
+Initiate Reply with a permanent/temporary error.
+
+Usage:
+python3.10 check_st20_reject_unsupported.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    # This check is specifically for nodes that do NOT support streams
+    pipSet = olcbchecker.gatherPIP(destination, always=True)
+    if pipSet is None:
+        logger.warning("Failed in setup, no PIP information received")
+        return (2)
+    if PIP.STREAM_PROTOCOL in pipSet :
+        logger.info("Passed - Stream protocol is in PIP, this check "
+                     "is for unsupported nodes only")
+        return(0)
+
+    # Send Stream Initiate Request
+    data = [0x01, 0x00, 0x00, 0x00, 0x01]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node correctly rejected with OIR")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+
+                if len(received.data) < 6 :
+                    logger.warning("Failure - Stream Initiate Reply too "
+                                   "short: {} bytes".format(
+                                       len(received.data)))
+                    return(3)
+
+                flags = (received.data[2] << 8) | received.data[3]
+                buf_size = (received.data[0] << 8) | received.data[1]
+
+                # Should be rejected
+                if flags == 0x0000 or flags == 0x8000 :
+                    if buf_size > 0 :
+                        logger.warning("Failure - node accepted stream "
+                                       "but does not advertise Stream "
+                                       "Protocol in PIP")
+                        return(3)
+
+                # Valid rejection
+                if (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    if buf_size != 0 :
+                        logger.warning("Failure - rejected but buffer "
+                                       "size non-zero: {}".format(buf_size))
+                        return(3)
+                    logger.info("Passed - node correctly rejected with "
+                                "Stream Initiate Reply error 0x{:04X}"
+                                .format(flags))
+                    return 0
+
+                logger.warning("Failure - unexpected flags 0x{:04X}"
+                               .format(flags))
+                return(3)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request "
+                           "from node that does not support streams")
+            return(3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st210_reject_then_retry.py
+++ b/check_st210_reject_then_retry.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a node recovers after rejecting a stream initiate and
+accepts a retry once resources are freed.
+
+Per StreamTransportS section 6.2, a node may reject a stream initiate
+with a temporary error (0x2020 buffer unavailable).  After the
+condition clears, a retry should succeed.
+
+Sequence:
+1. PIP guard
+2. Open streams until one is rejected (temporary error)
+3. If no rejection after 4 attempts, pass -- node has deep pool
+4. Close one open stream to free resources
+5. Retry the rejected initiate
+6. Verify the retry succeeds
+7. Close all streams
+
+Usage:
+python3.10 check_st210_reject_then_retry.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream.
+    Returns (buf_size, did, rejected) where rejected is True if the
+    node sent a rejection or OIR.'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None, True)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None, True)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did, False)
+                else :
+                    return (None, None, True)
+            continue
+        except Empty:
+            return (None, None, True)
+
+
+def _close_stream(destination, sid, did):
+    '''Send Stream Data Complete to close a stream.'''
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open streams until we get a rejection
+    max_attempts = 4
+    open_streams = []  # list of (sid, did)
+    rejected_sid = None
+
+    for i in range(max_attempts) :
+        sid = 0xD0 + i
+        buf_size, did, rejected = _open_stream(
+            logger, destination, 256, sid)
+
+        if rejected and len(open_streams) == 0 :
+            logger.info("Passed - node does not accept streams, "
+                         "cannot test reject-then-retry")
+            return 0
+
+        if rejected :
+            rejected_sid = sid
+            logger.info("  stream 0x{:02X} rejected after {} "
+                         "accepted".format(sid, len(open_streams)))
+            break
+
+        open_streams.append((sid, did))
+
+    if rejected_sid is None :
+        # Node accepted all 4 -- deep pool, cannot force rejection
+        for sid, did in open_streams :
+            _close_stream(destination, sid, did)
+        logger.info("Passed - node accepted all {} streams, "
+                     "cannot force rejection".format(max_attempts))
+        return 0
+
+    # Close one stream to free resources
+    freed_sid, freed_did = open_streams.pop(0)
+    _close_stream(destination, freed_sid, freed_did)
+    logger.info("  closed stream 0x{:02X} to free resources".format(
+        freed_sid))
+
+    # Brief pause for the node to process the close
+    olcbchecker.purgeMessages()
+    time.sleep(0.3)
+
+    # Retry the rejected SID
+    buf_size, did, rejected = _open_stream(
+        logger, destination, 256, rejected_sid)
+
+    if rejected :
+        logger.warning("Failure - retry after freeing resources was "
+                       "still rejected")
+        for sid, did_open in open_streams :
+            _close_stream(destination, sid, did_open)
+        return(3)
+
+    logger.info("  retry stream 0x{:02X} accepted with DID "
+                 "0x{:02X}".format(rejected_sid, did))
+
+    # Close all remaining streams
+    open_streams.append((rejected_sid, did))
+    for sid, did_open in open_streams :
+        _close_stream(destination, sid, did_open)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st30_buffer_negotiation.py
+++ b/check_st30_buffer_negotiation.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the negotiated buffer size in Stream Initiate Reply
+never exceeds what was proposed in the Stream Initiate Request.
+
+Per StreamTransportS section 7.1, the Max Buffer Size in the reply must
+be less than or equal to what was proposed in the request.
+
+Usage:
+python3.10 check_st30_buffer_negotiation.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _send_initiate_and_check(logger, destination, proposed_size, sid):
+    '''Send a Stream Initiate Request and validate the reply buffer size.
+
+    Returns (result_code, did) where did is the assigned DID if accepted.
+    '''
+    import olcbchecker
+    data = [
+        (proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+        0x00, 0x00,
+        sid
+    ]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("  Node rejected with OIR for size {}"
+                            .format(proposed_size))
+                return (0, None)
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    logger.warning("Failure - reply too short")
+                    return (3, None)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted
+                    if buf_size > proposed_size :
+                        logger.warning("Failure - reply buffer size {} "
+                                       "exceeds proposed {}"
+                                       .format(buf_size, proposed_size))
+                        return (3, did)
+                    if buf_size == 0 :
+                        logger.warning("Failure - accepted with zero "
+                                       "buffer size")
+                        return (3, did)
+                    return (0, did)
+                elif (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    # rejected
+                    logger.info("  Node rejected for size {} with "
+                                "error 0x{:04X}"
+                                .format(proposed_size, flags))
+                    return (0, None)
+                else :
+                    logger.warning("Failure - invalid flags 0x{:04X}"
+                                   .format(flags))
+                    return (3, None)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply for proposed size {}"
+                           .format(proposed_size))
+            return (3, None)
+
+
+def _close_stream(destination, sid, did):
+    import olcbchecker
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(message)
+    time.sleep(0.3)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Test with buffer size 64
+    sid = 0x10
+    result, did = _send_initiate_and_check(logger, destination, 64, sid)
+    if result != 0 :
+        return result
+    if did is not None :
+        _close_stream(destination, sid, did)
+
+    olcbchecker.purgeMessages()
+
+    # Test with buffer size 1024
+    sid = 0x11
+    result, did = _send_initiate_and_check(logger, destination, 1024, sid)
+    if result != 0 :
+        return result
+    if did is not None :
+        _close_stream(destination, sid, did)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st35_min_buffer.py
+++ b/check_st35_min_buffer.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3.10
+'''
+This checks behavior when requesting the smallest possible buffer size (1).
+
+Per StreamTransportS, Max Buffer Size range is [1..65535]. The node
+should either accept with buffer size 1 or reject with a valid error.
+
+Usage:
+python3.10 check_st35_min_buffer.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Send Stream Initiate Request with buffer size = 1
+    sid = 0x20
+    data = [0x00, 0x01, 0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node rejected with OIR")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    logger.warning("Failure - reply too short: {} bytes"
+                                   .format(len(received.data)))
+                    return(3)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted
+                    if buf_size != 1 :
+                        logger.warning("Failure - accepted with buffer "
+                                       "size {} instead of 1"
+                                       .format(buf_size))
+                        return(3)
+                    # close the stream
+                    complete = Message(MTI.Stream_Data_Complete,
+                                      NodeID(olcbchecker.ownnodeid()),
+                                      destination, [sid, did])
+                    olcbchecker.sendMessage(complete)
+                    time.sleep(0.3)
+                    logger.info("Passed")
+                    return 0
+
+                elif (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    # rejected with valid error
+                    logger.info("Passed - node rejected min buffer with "
+                                "error 0x{:04X}".format(flags))
+                    return 0
+
+                else :
+                    logger.warning("Failure - invalid flags 0x{:04X}"
+                                   .format(flags))
+                    return(3)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request")
+            return(3)
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st37_max_buffer.py
+++ b/check_st37_max_buffer.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3.10
+'''
+This checks behavior when requesting the largest possible buffer size (65535).
+
+Per StreamTransportS, the reply Max Buffer Size must be less than or equal
+to the proposed value. The node should negotiate down to its capability.
+
+Usage:
+python3.10 check_st37_max_buffer.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Send Stream Initiate Request with buffer size = 0xFFFF
+    sid = 0x30
+    data = [0xFF, 0xFF, 0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node rejected with OIR")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    logger.warning("Failure - reply too short: {} bytes"
+                                   .format(len(received.data)))
+                    return(3)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted
+                    if buf_size > 0xFFFF :
+                        logger.warning("Failure - reply buffer size {} "
+                                       "exceeds proposed 65535"
+                                       .format(buf_size))
+                        return(3)
+                    if buf_size == 0 :
+                        logger.warning("Failure - accepted with zero "
+                                       "buffer size")
+                        return(3)
+                    logger.info("  Node negotiated buffer to {}"
+                                .format(buf_size))
+                    # close the stream
+                    complete = Message(MTI.Stream_Data_Complete,
+                                      NodeID(olcbchecker.ownnodeid()),
+                                      destination, [sid, did])
+                    olcbchecker.sendMessage(complete)
+                    time.sleep(0.3)
+                    logger.info("Passed")
+                    return 0
+
+                elif (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    logger.info("Passed - node rejected with error "
+                                "0x{:04X}".format(flags))
+                    return 0
+
+                else :
+                    logger.warning("Failure - invalid flags 0x{:04X}"
+                                   .format(flags))
+                    return(3)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request")
+            return(3)
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st40_unknown_content_uid.py
+++ b/check_st40_unknown_content_uid.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3.10
+'''
+This checks behavior when sending a Stream Initiate Request without prior
+announcement and with an unknown Stream Content UID.
+
+Per StreamTransportS section 7.2, if the Stream Content UID is unknown to
+the destination node, it should use the Permanent Error, Unimplemented
+error code (0x1040) in the rejection message. Acceptance is also valid.
+
+Usage:
+python3.10 check_st40_unknown_content_uid.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Send 12-byte Stream Initiate Request with unknown Content UID
+    # Bytes 0-1: Max Buffer Size = 256
+    # Bytes 2-3: Flags = 0x0000
+    # Byte 4: Source Stream ID = 0x40
+    # Byte 5: Proposed Destination Stream ID = 0x00
+    # Bytes 6-11: Fabricated Stream Content UID
+    sid = 0x40
+    data = [0x01, 0x00, 0x00, 0x00, sid, 0x00,
+            0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node rejected with OIR")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    logger.warning("Failure - reply too short: {} bytes"
+                                   .format(len(received.data)))
+                    return(3)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted - this is valid per spec
+                    logger.info("  Node accepted unknown Content UID "
+                                "(valid per spec)")
+                    # close the stream
+                    complete = Message(MTI.Stream_Data_Complete,
+                                      NodeID(olcbchecker.ownnodeid()),
+                                      destination, [sid, did])
+                    olcbchecker.sendMessage(complete)
+                    time.sleep(0.3)
+                    logger.info("Passed")
+                    return 0
+
+                elif (flags & 0xF000) == 0x1000 or \
+                        (flags & 0xF000) == 0x2000 :
+                    # rejected - expected, especially 0x1040
+                    if buf_size != 0 :
+                        logger.warning("Failure - rejected but buffer "
+                                       "size non-zero: {}".format(buf_size))
+                        return(3)
+                    logger.info("Passed - node rejected unknown UID with "
+                                "error 0x{:04X}".format(flags))
+                    return 0
+
+                else :
+                    logger.warning("Failure - invalid flags 0x{:04X}"
+                                   .format(flags))
+                    return(3)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request "
+                           "with unknown Content UID")
+            return(3)
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st50_initiate_reply_format.py
+++ b/check_st50_initiate_reply_format.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3.10
+'''
+This validates every field in the Stream Initiate Reply message.
+
+Per StreamTransportS section 5.2, the reply must contain:
+- Bytes 0-1: Max Buffer Size (final value, or 0 if rejected)
+- Bytes 2-3: Flags and Error Codes
+- Byte 4: Source Stream ID (must echo the request)
+- Byte 5: Destination Stream ID (0x00-0xFE, 0xFF reserved)
+
+Usage:
+python3.10 check_st50_initiate_reply_format.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Send Stream Initiate Request with distinctive SID 0x42
+    sid = 0x42
+    proposed_size = 512
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node responded with OIR")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+
+                # Validate length
+                if len(received.data) < 6 :
+                    logger.warning("Failure - Stream Initiate Reply must "
+                                   "be at least 6 bytes, got {}"
+                                   .format(len(received.data)))
+                    return(3)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                reply_sid = received.data[4]
+                did = received.data[5]
+
+                # Validate SID echoed exactly
+                if reply_sid != sid :
+                    logger.warning("Failure - Source Stream ID not echoed "
+                                   "correctly: sent 0x{:02X}, got "
+                                   "0x{:02X}".format(sid, reply_sid))
+                    return(3)
+
+                # Validate DID not reserved
+                if did == 0xFF :
+                    logger.warning("Failure - Destination Stream ID uses "
+                                   "reserved value 0xFF")
+                    return(3)
+
+                # Validate flags/buffer consistency
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted
+                    if buf_size == 0 :
+                        logger.warning("Failure - accepted (flags "
+                                       "0x{:04X}) but buffer size is 0"
+                                       .format(flags))
+                        return(3)
+                    if buf_size > proposed_size :
+                        logger.warning("Failure - reply buffer {} exceeds "
+                                       "proposed {}".format(buf_size,
+                                                            proposed_size))
+                        return(3)
+                    # close the stream
+                    complete = Message(MTI.Stream_Data_Complete,
+                                      NodeID(olcbchecker.ownnodeid()),
+                                      destination, [sid, did])
+                    olcbchecker.sendMessage(complete)
+                    time.sleep(0.3)
+
+                elif (flags & 0xF000) == 0x1000 :
+                    # permanent error
+                    if buf_size != 0 :
+                        logger.warning("Failure - permanent error but "
+                                       "buffer size non-zero: {}"
+                                       .format(buf_size))
+                        return(3)
+                    # validate specific error codes
+                    valid_codes = [0x1000, 0x1010, 0x1020, 0x1040]
+                    if flags not in valid_codes :
+                        logger.warning("Failure - unknown permanent error "
+                                       "code 0x{:04X}".format(flags))
+                        return(3)
+
+                elif (flags & 0xF000) == 0x2000 :
+                    # temporary error
+                    if buf_size != 0 :
+                        logger.warning("Failure - temporary error but "
+                                       "buffer size non-zero: {}"
+                                       .format(buf_size))
+                        return(3)
+                    valid_codes = [0x2000, 0x2020, 0x2040]
+                    if flags not in valid_codes :
+                        logger.warning("Failure - unknown temporary error "
+                                       "code 0x{:04X}".format(flags))
+                        return(3)
+
+                else :
+                    logger.warning("Failure - invalid flags pattern "
+                                   "0x{:04X}".format(flags))
+                    return(3)
+
+                break
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no reply to Stream Initiate Request")
+            return(3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st60_data_send.py
+++ b/check_st60_data_send.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3.10
+'''
+This checks basic stream data transfer and flow control.
+
+Opens a stream, sends exactly MaxBufSize bytes of data, and verifies
+that the destination sends a Stream Data Proceed message.
+
+Per StreamTransportS section 7.3, after sending MaxBufSize bytes the
+source pauses, and the destination sends a Stream Data Proceed when
+ready for more.
+
+Usage:
+python3.10 check_st60_data_send.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+
+            continue
+
+        except Empty:
+            return (None, None)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0x60
+    buf_size, did = _open_stream(logger, destination, 256, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test data transfer")
+        return 0
+
+    # Send exactly MaxBufSize bytes of payload
+    # Stream Data Send: byte 0 = DID, bytes 1+ = payload
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [(bytes_sent + i) & 0xFF for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+    # Wait for Stream Data Proceed
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Stream Data Proceed too "
+                                   "short: {} bytes"
+                                   .format(len(received.data)))
+                    # still close the stream
+                    break
+
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch: "
+                                   "expected 0x{:02X}, got 0x{:02X}"
+                                   .format(sid, received.data[0]))
+                    break
+
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch: "
+                                   "expected 0x{:02X}, got 0x{:02X}"
+                                   .format(did, received.data[1]))
+                    break
+
+                # Success - got valid Proceed
+                complete = Message(MTI.Stream_Data_Complete,
+                                  NodeID(olcbchecker.ownnodeid()),
+                                  destination, [sid, did])
+                olcbchecker.sendMessage(complete)
+                time.sleep(0.3)
+                logger.info("Passed")
+                return 0
+
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - node sent Terminate Due To "
+                               "Error during data transfer")
+                return(3)
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - no Stream Data Proceed received "
+                           "after sending {} bytes".format(bytes_sent))
+            # close the stream
+            complete = Message(MTI.Stream_Data_Complete,
+                              NodeID(olcbchecker.ownnodeid()),
+                              destination, [sid, did])
+            olcbchecker.sendMessage(complete)
+            time.sleep(0.3)
+            return(3)
+
+    # If we broke out with an error, close and fail
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+    return(3)
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st65_data_proceed_flow.py
+++ b/check_st65_data_proceed_flow.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3.10
+'''
+This checks flow control across multiple buffer cycles.
+
+Opens a stream, sends MaxBufSize bytes, waits for Proceed, sends
+another MaxBufSize bytes, waits for a second Proceed, then closes.
+
+Per StreamTransportS section 7.3, each Stream Data Proceed extends the
+window by MaxBufSize.
+
+Usage:
+python3.10 check_st65_data_proceed_flow.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def _send_buffer(destination, did, buf_size, offset=0):
+    '''Send exactly buf_size bytes of stream data.'''
+    import olcbchecker
+    bytes_sent = 0
+    while bytes_sent < buf_size :
+        chunk_size = min(buf_size - bytes_sent, 64)
+        payload = [((offset + bytes_sent + i) & 0xFF)
+                   for i in range(chunk_size)]
+        data = [did] + payload
+        message = Message(MTI.Stream_Data_Send,
+                          NodeID(olcbchecker.ownnodeid()), destination, data)
+        olcbchecker.sendMessage(message)
+        bytes_sent += chunk_size
+
+
+def _wait_for_proceed(logger, destination, sid, did, cycle_num):
+    '''Wait for a Stream Data Proceed. Returns True on success.'''
+    import olcbchecker
+    while True :
+        try :
+            received = olcbchecker.getMessage(3.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Stream_Data_Proceed :
+                if len(received.data) < 2 :
+                    logger.warning("Failure - Proceed too short in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[0] != sid :
+                    logger.warning("Failure - Proceed SID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                if received.data[1] != did :
+                    logger.warning("Failure - Proceed DID mismatch in "
+                                   "cycle {}".format(cycle_num))
+                    return False
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - Terminate Due To Error in "
+                               "cycle {}".format(cycle_num))
+                return False
+            continue
+        except Empty:
+            logger.warning("Failure - no Proceed in cycle {}"
+                           .format(cycle_num))
+            return False
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0x65
+    buf_size, did = _open_stream(logger, destination, 256, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test flow control")
+        return 0
+
+    # Cycle 1: send buffer, wait for Proceed
+    _send_buffer(destination, did, buf_size, offset=0)
+    if not _wait_for_proceed(logger, destination, sid, did, 1) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Cycle 2: send another buffer, wait for Proceed
+    _send_buffer(destination, did, buf_size, offset=buf_size)
+    if not _wait_for_proceed(logger, destination, sid, did, 2) :
+        complete = Message(MTI.Stream_Data_Complete,
+                          NodeID(olcbchecker.ownnodeid()), destination,
+                          [sid, did])
+        olcbchecker.sendMessage(complete)
+        time.sleep(0.3)
+        return(3)
+
+    # Close the stream
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st70_complete.py
+++ b/check_st70_complete.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3.10
+'''
+This checks that a stream can be cleanly closed and reopened.
+
+Opens a stream, sends some data (less than MaxBufSize), sends Stream
+Data Complete, verifies no errors, then opens a new stream to confirm
+the node freed its resources.
+
+Per StreamTransportS section 7.4, Stream Data Complete transitions the
+stream to Closed state.
+
+Usage:
+python3.10 check_st70_complete.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Open first stream
+    sid1 = 0x70
+    buf_size, did1 = _open_stream(logger, destination, 256, sid1)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test completion")
+        return 0
+
+    # Send a small amount of data (less than MaxBufSize)
+    small_size = min(buf_size - 1, 10) if buf_size > 1 else 1
+    payload = list(range(small_size))
+    data = [did1] + payload
+    message = Message(MTI.Stream_Data_Send,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    # Send Stream Data Complete
+    total_bytes = small_size
+    complete_data = [sid1, did1]
+    message = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      complete_data)
+    olcbchecker.sendMessage(message)
+
+    # Brief pause then check for errors
+    time.sleep(0.5)
+
+    # Check for any error messages
+    while True :
+        try :
+            received = olcbchecker.getMessage(0.5)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Terminate_Due_To_Error :
+                logger.warning("Failure - node sent Terminate Due To "
+                               "Error after Stream Data Complete")
+                return(3)
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted after stream "
+                               "completion")
+                return(3)
+        except Empty:
+            break
+
+    # Open a second stream to verify resources were freed
+    sid2 = 0x71
+    buf_size2, did2 = _open_stream(logger, destination, 256, sid2)
+
+    if buf_size2 is None :
+        logger.warning("Failure - could not reopen stream after "
+                       "closing first stream")
+        return(3)
+
+    # Close the second stream
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid2, did2])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st80_terminate_error.py
+++ b/check_st80_terminate_error.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the DUT handles a Terminate Due To Error during an
+open stream gracefully.
+
+Per StreamTransportS section 7.4, a stream is closed if the remote node
+sends a Terminate Due To Error whose rejected MTI is Stream Data Send
+or Stream Data Proceed.
+
+Test A: TDE with rejected MTI = Stream Data Proceed (0x0888)
+Test B: TDE with rejected MTI = Stream Data Send (0x1F88)
+
+Both tests verify that the stream slot is freed (re-open succeeds)
+and the node does not reboot.
+
+Usage:
+python3.10 check_st80_terminate_error.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def _open_stream(logger, destination, proposed_size, sid):
+    '''Attempt to open a stream. Returns (buf_size, did) or (None, None).'''
+    import olcbchecker
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                return (None, None)
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    return (None, None)
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0 :
+                    return (buf_size, did)
+                else :
+                    return (None, None)
+            continue
+        except Empty:
+            return (None, None)
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    sid = 0x80
+    buf_size, did = _open_stream(logger, destination, 256, sid)
+
+    if buf_size is None :
+        logger.info("Passed - node does not accept streams, cannot "
+                     "test error termination")
+        return 0
+
+    # --- Test A: TDE with rejected MTI = Stream Data Proceed (0x0888) ---
+
+    # Send Terminate Due To Error to close the stream abruptly.
+    # Per Message Network Standard, TDE payload is:
+    #   bytes 0-1 = error code (use 0x1000 Permanent error)
+    #   bytes 2-3 = rejected MTI
+    error_code = 0x1000
+    rejected_mti = MTI.Stream_Data_Proceed.value
+    error_data = [
+        (error_code >> 8) & 0xFF, error_code & 0xFF,
+        (rejected_mti >> 8) & 0xFF, rejected_mti & 0xFF
+    ]
+    message = Message(MTI.Terminate_Due_To_Error,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      error_data)
+    olcbchecker.sendMessage(message)
+
+    time.sleep(1.0)
+
+    # Check that the node has not rebooted
+    while True :
+        try :
+            received = olcbchecker.getMessage(0.5)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted after Terminate "
+                               "Due To Error (Stream Data Proceed)")
+                return(3)
+        except Empty:
+            break
+
+    # Verify node is still alive
+    olcbchecker.purgeMessages()
+    message = Message(MTI.Verify_NodeID_Number_Addressed,
+                      NodeID(olcbchecker.ownnodeid()), destination)
+    olcbchecker.sendMessage(message)
+
+    alive = False
+    while True :
+        try :
+            received = olcbchecker.getMessage()
+            if received.mti != MTI.Verified_NodeID and \
+                    received.mti != MTI.Verified_NodeID_Simple :
+                continue
+            if destination != received.source :
+                continue
+            alive = True
+            break
+        except Empty:
+            break
+
+    if not alive :
+        logger.warning("Failure - node not responding after Terminate "
+                       "Due To Error (Stream Data Proceed)")
+        return(3)
+
+    # Stream slot must be freed -- require re-open to succeed
+    sid2 = 0x81
+    buf_size2, did2 = _open_stream(logger, destination, 256, sid2)
+
+    if buf_size2 is None :
+        logger.warning("Failure - stream slot not freed after Terminate "
+                       "Due To Error (Stream Data Proceed)")
+        return(3)
+
+    # Close the recovery stream cleanly
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid2, did2])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    # --- Test B: TDE with rejected MTI = Stream Data Send (0x1F88) ---
+
+    sid3 = 0x82
+    buf_size3, did3 = _open_stream(logger, destination, 256, sid3)
+
+    if buf_size3 is None :
+        logger.info("Passed - Test A passed but node declined second "
+                    "stream for Test B, skipping Send variant")
+        return 0
+
+    rejected_mti_send = MTI.Stream_Data_Send.value
+    error_data_send = [
+        (error_code >> 8) & 0xFF, error_code & 0xFF,
+        (rejected_mti_send >> 8) & 0xFF, rejected_mti_send & 0xFF
+    ]
+    message = Message(MTI.Terminate_Due_To_Error,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      error_data_send)
+    olcbchecker.sendMessage(message)
+
+    time.sleep(1.0)
+
+    # Check that the node has not rebooted
+    while True :
+        try :
+            received = olcbchecker.getMessage(0.5)
+            if destination != received.source :
+                continue
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted after Terminate "
+                               "Due To Error (Stream Data Send)")
+                return(3)
+        except Empty:
+            break
+
+    # Verify node is still alive
+    olcbchecker.purgeMessages()
+    message = Message(MTI.Verify_NodeID_Number_Addressed,
+                      NodeID(olcbchecker.ownnodeid()), destination)
+    olcbchecker.sendMessage(message)
+
+    alive = False
+    while True :
+        try :
+            received = olcbchecker.getMessage()
+            if received.mti != MTI.Verified_NodeID and \
+                    received.mti != MTI.Verified_NodeID_Simple :
+                continue
+            if destination != received.source :
+                continue
+            alive = True
+            break
+        except Empty:
+            break
+
+    if not alive :
+        logger.warning("Failure - node not responding after Terminate "
+                       "Due To Error (Stream Data Send)")
+        return(3)
+
+    # Stream slot must be freed -- require re-open to succeed
+    sid4 = 0x83
+    buf_size4, did4 = _open_stream(logger, destination, 256, sid4)
+
+    if buf_size4 is None :
+        logger.warning("Failure - stream slot not freed after Terminate "
+                       "Due To Error (Stream Data Send)")
+        return(3)
+
+    # Close the recovery stream cleanly
+    complete = Message(MTI.Stream_Data_Complete,
+                      NodeID(olcbchecker.ownnodeid()), destination,
+                      [sid4, did4])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st85_stability.py
+++ b/check_st85_stability.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3.10
+'''
+This checks that the node remains stable after stream operations with
+a 30-second stability soak.
+
+Opens and closes a stream (or handles rejection), then monitors the
+node for 30 seconds, periodically pinging to verify responsiveness.
+
+Usage:
+python3.10 check_st85_stability.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    if olcbchecker.isCheckPip() :
+        pipSet = olcbchecker.gatherPIP(destination)
+        if pipSet is None:
+            logger.warning("Failed in setup, no PIP information received")
+            return (2)
+        if not PIP.STREAM_PROTOCOL in pipSet :
+            logger.info("Passed - due to Stream protocol not in PIP")
+            return(0)
+
+    # Attempt to open and close a stream
+    sid = 0x85
+    data = [0x01, 0x00, 0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                break  # no stream to close
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) >= 6 :
+                    flags = (received.data[2] << 8) | received.data[3]
+                    buf_size = (received.data[0] << 8) | received.data[1]
+                    did = received.data[5]
+                    if (flags == 0x0000 or flags == 0x8000) \
+                            and buf_size > 0 :
+                        # accepted - close it
+                        complete = Message(MTI.Stream_Data_Complete,
+                                          NodeID(olcbchecker.ownnodeid()),
+                                          destination, [sid, did])
+                        olcbchecker.sendMessage(complete)
+                        time.sleep(0.3)
+                break
+
+        except Empty:
+            break
+
+    # Stability soak: 30 seconds, pinging every 10s
+    timeout = 30
+    ping_interval = 10
+    last_ping = 0
+    logger.info("Stability soak: monitoring node for {} seconds".format(
+        timeout))
+    start = time.time()
+
+    while time.time() - start < timeout :
+        try :
+            received = olcbchecker.getMessage(1)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Initialization_Complete or \
+                    received.mti == MTI.Initialization_Complete_Simple :
+                logger.warning("Failure - node rebooted during stability "
+                               "soak after stream operations")
+                return(3)
+
+        except Empty:
+            pass
+
+        if time.time() - last_ping >= ping_interval :
+            elapsed = int(time.time() - start)
+            logger.info("  soak {}/{}s - pinging node...".format(
+                elapsed, timeout))
+            olcbchecker.purgeMessages()
+            message = Message(MTI.Verify_NodeID_Number_Addressed,
+                              NodeID(olcbchecker.ownnodeid()), destination)
+            olcbchecker.sendMessage(message)
+
+            alive = False
+            while True :
+                try :
+                    received = olcbchecker.getMessage()
+                    if received.mti != MTI.Verified_NodeID and \
+                            received.mti != MTI.Verified_NodeID_Simple :
+                        continue
+                    if destination != received.source :
+                        continue
+                    alive = True
+                    break
+                except Empty:
+                    break
+
+            if not alive :
+                logger.warning("Failure - node stopped responding during "
+                               "stability soak")
+                return(3)
+
+            last_ping = time.time()
+
+    logger.info("Passed")
+    return 0
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/check_st90_oir_fallback.py
+++ b/check_st90_oir_fallback.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3.10
+'''
+This verifies that when a node has STREAM_PROTOCOL in PIP, it responds
+to a Stream Initiate Request with either a Stream Initiate Reply or
+an Optional Interaction Rejected (OIR) message.
+
+Both responses are valid per StreamTransportS section 7.1. OIR is a
+spec-legal fallback. Failure is if neither is received.
+
+Usage:
+python3.10 check_st90_oir_fallback.py
+
+The -h option will display a full list of options.
+'''
+
+import sys
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+from openlcb.pip import PIP
+
+from queue import Empty
+
+
+def check():
+    import olcbchecker.setup
+    logger = logging.getLogger("STREAM")
+
+    olcbchecker.purgeMessages()
+
+    destination = olcbchecker.getTargetID()
+
+    ###############################
+    # checking sequence starts here
+    ###############################
+
+    # This check requires STREAM_PROTOCOL in PIP
+    pipSet = olcbchecker.gatherPIP(destination, always=True)
+    if pipSet is None:
+        logger.warning("Failed in setup, no PIP information received")
+        return (2)
+    if not PIP.STREAM_PROTOCOL in pipSet :
+        logger.info("Passed - Stream protocol not in PIP, this check "
+                     "is for stream-capable nodes only")
+        return(0)
+
+    # Send Stream Initiate Request
+    sid = 0x90
+    data = [0x01, 0x00, 0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True :
+        try :
+            received = olcbchecker.getMessage(2.0)
+
+            if destination != received.source :
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected :
+                logger.info("Passed - node responded with OIR "
+                            "(spec-legal fallback)")
+                return 0
+
+            if received.mti == MTI.Stream_Initiate_Reply :
+                if NodeID(olcbchecker.ownnodeid()) != received.destination :
+                    continue
+                if len(received.data) < 6 :
+                    logger.warning("Failure - reply too short: {} bytes"
+                                   .format(len(received.data)))
+                    return(3)
+
+                flags = (received.data[2] << 8) | received.data[3]
+                buf_size = (received.data[0] << 8) | received.data[1]
+                did = received.data[5]
+
+                if flags == 0x0000 or flags == 0x8000 :
+                    # accepted - close it
+                    if buf_size > 0 :
+                        complete = Message(MTI.Stream_Data_Complete,
+                                          NodeID(olcbchecker.ownnodeid()),
+                                          destination, [sid, did])
+                        olcbchecker.sendMessage(complete)
+                        time.sleep(0.3)
+
+                logger.info("Passed - node responded with Stream "
+                            "Initiate Reply")
+                return 0
+
+            continue
+
+        except Empty:
+            logger.warning("Failure - node with STREAM_PROTOCOL in PIP "
+                           "did not respond to Stream Initiate Request "
+                           "with either Reply or OIR")
+            return(3)
+
+
+if __name__ == "__main__":
+    result = check()
+    import olcbchecker
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/control_datagram.py
+++ b/control_datagram.py
@@ -62,7 +62,7 @@ def main() :
             case "q" | "quit" : return
 
             case _ : continue
-                   
+
     return
 
 if __name__ == "__main__":

--- a/control_master.py
+++ b/control_master.py
@@ -25,6 +25,7 @@ def prompt() :
     print(" 8 Train Search checking")
     print(" 9 Function Definition Information (FDI) checking")
     print("10 Broadcast Time Protocol checking")
+    print("11 Stream Transport checking")
     print("  ")
     print(" a Run all in sequence without three train protocols")
     print(" t Run all in sequence including three train protocols")
@@ -55,6 +56,8 @@ def checkAll() :
     total += min(control_fdi.checkAll(),1)
     import control_broadcasttime
     total += min(control_broadcasttime.checkAll(),1)
+    import control_stream
+    total += min(control_stream.checkAll(),1)
 
     logger = logging.getLogger("OLCBCHECKER")
     if total > 0 :
@@ -79,14 +82,16 @@ def checkAllNoTrains() :
     total += min(control_memory.checkAll(),1)
     import control_cdi
     total += min(control_cdi.checkAll(),1)
-    
+    import control_stream
+    total += min(control_stream.checkAll(),1)
+
     logger = logging.getLogger("OLCBCHECKER")
     if total > 0 :
         logger.info("{} sections had failures".format(total))
     else :
         logger.info("All sections passed")
     return total;
- 
+
 def main() :
 
     # if immediate running has been requested, do that
@@ -148,6 +153,10 @@ def main() :
             case "10" :
                 import control_broadcasttime
                 control_broadcasttime.main()
+
+            case "11" :
+                import control_stream
+                control_stream.main()
 
             case "a" : 
                 checkAllNoTrains()    

--- a/control_stream.py
+++ b/control_stream.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3.10
+
+'''
+Simple runner for Stream Transport suite
+'''
+import sys
+import logging
+
+import olcbchecker.setup
+
+import check_st10_initiate
+import check_st20_reject_unsupported
+import check_st30_buffer_negotiation
+import check_st35_min_buffer
+import check_st37_max_buffer
+import check_st40_unknown_content_uid
+import check_st50_initiate_reply_format
+import check_st60_data_send
+import check_st65_data_proceed_flow
+import check_st70_complete
+import check_st80_terminate_error
+import check_st85_stability
+import check_st90_oir_fallback
+import check_st100_concurrent_same_node
+import check_st110_concurrent_multi_node
+import check_st120_sustained_transfer
+import check_st130_min_chunk_send
+import check_st140_concurrent_sustained
+import check_st150_asymmetric_buffers
+import check_st155_negotiation_enforcement
+import check_st170_zero_payload_flush
+import check_st180_interleaved_data_send
+import check_st190_suggested_did
+import check_st200_complete_with_byte_count
+import check_st210_reject_then_retry
+
+def prompt() :
+    print("\nStream Transport Standard checking")
+    print(" a Run all in sequence")
+    print(" 1 Stream Initiate Request/Reply checking")
+    print(" 2 Reject when unsupported checking")
+    print(" 3 Buffer negotiation checking")
+    print(" 4 Minimum buffer size checking")
+    print(" 5 Maximum buffer size checking")
+    print(" 6 Unknown Content UID checking")
+    print(" 7 Initiate Reply format checking")
+    print(" 8 Data send and Proceed checking")
+    print(" 9 Data Proceed flow control checking")
+    print("10 Stream completion checking")
+    print("11 Terminate Due To Error checking")
+    print("12 Post-stream stability checking")
+    print("13 OIR fallback checking")
+    print("14 Concurrent streams (same node) checking")
+    print("15 Concurrent streams (multi node) checking")
+    print("16 Sustained transfer checking")
+    print("17 Minimum chunk send checking")
+    print("18 Concurrent sustained checking")
+    print("19 Asymmetric buffers checking")
+    print("20 Negotiation enforcement checking")
+    print("21 Zero-payload flush checking")
+    print("22 Interleaved data send checking")
+    print("23 Suggested DID checking")
+    print("24 Complete with byte count checking")
+    print("25 Reject then retry checking")
+    print("  ")
+    print(" q go back")
+
+def checkAll(logger=logging.getLogger("STREAM")) :
+    result = 0
+
+    logger.info("Stream Initiate Request/Reply checking")
+    result += check_st10_initiate.check()
+
+    logger.info("Reject when unsupported checking")
+    result += check_st20_reject_unsupported.check()
+
+    logger.info("Buffer negotiation checking")
+    result += check_st30_buffer_negotiation.check()
+
+    logger.info("Minimum buffer size checking")
+    result += check_st35_min_buffer.check()
+
+    logger.info("Maximum buffer size checking")
+    result += check_st37_max_buffer.check()
+
+    logger.info("Unknown Content UID checking")
+    result += check_st40_unknown_content_uid.check()
+
+    logger.info("Initiate Reply format checking")
+    result += check_st50_initiate_reply_format.check()
+
+    logger.info("Data send and Proceed checking")
+    result += check_st60_data_send.check()
+
+    logger.info("Data Proceed flow control checking")
+    result += check_st65_data_proceed_flow.check()
+
+    logger.info("Stream completion checking")
+    result += check_st70_complete.check()
+
+    logger.info("Terminate Due To Error checking")
+    result += check_st80_terminate_error.check()
+
+    logger.info("Post-stream stability checking")
+    result += check_st85_stability.check()
+
+    logger.info("OIR fallback checking")
+    result += check_st90_oir_fallback.check()
+
+    logger.info("Concurrent streams (same node) checking")
+    result += check_st100_concurrent_same_node.check()
+
+    logger.info("Concurrent streams (multi node) checking")
+    result += check_st110_concurrent_multi_node.check()
+
+    logger.info("Sustained transfer checking")
+    result += check_st120_sustained_transfer.check()
+
+    logger.info("Minimum chunk send checking")
+    result += check_st130_min_chunk_send.check()
+
+    logger.info("Concurrent sustained checking")
+    result += check_st140_concurrent_sustained.check()
+
+    logger.info("Asymmetric buffers checking")
+    result += check_st150_asymmetric_buffers.check()
+
+    logger.info("Negotiation enforcement checking")
+    result += check_st155_negotiation_enforcement.check()
+
+    logger.info("Zero-payload flush checking")
+    result += check_st170_zero_payload_flush.check()
+
+    logger.info("Interleaved data send checking")
+    result += check_st180_interleaved_data_send.check()
+
+    logger.info("Suggested DID checking")
+    result += check_st190_suggested_did.check()
+
+    logger.info("Complete with byte count checking")
+    result += check_st200_complete_with_byte_count.check()
+
+    logger.info("Reject then retry checking")
+    result += check_st210_reject_then_retry.check()
+
+    if result == 0 :
+        logger.info("Success - all stream checks passed")
+    else:
+        logger.warning("At least one stream check failed")
+
+    return result
+
+def main() :
+    logger = logging.getLogger("STREAM")
+
+    if olcbchecker.setup.configure.runimmediate :
+        return (checkAll(logger))
+
+    '''
+    loop to check against Stream Transport Standard
+    '''
+    while True :
+        prompt()
+        selection = input(">> ").lower()
+        match selection :
+            case "1" :
+                print("\nStream Initiate Request/Reply checking")
+                check_st10_initiate.check()
+
+            case "2" :
+                print("\nReject when unsupported checking")
+                check_st20_reject_unsupported.check()
+
+            case "3" :
+                print("\nBuffer negotiation checking")
+                check_st30_buffer_negotiation.check()
+
+            case "4" :
+                print("\nMinimum buffer size checking")
+                check_st35_min_buffer.check()
+
+            case "5" :
+                print("\nMaximum buffer size checking")
+                check_st37_max_buffer.check()
+
+            case "6" :
+                print("\nUnknown Content UID checking")
+                check_st40_unknown_content_uid.check()
+
+            case "7" :
+                print("\nInitiate Reply format checking")
+                check_st50_initiate_reply_format.check()
+
+            case "8" :
+                print("\nData send and Proceed checking")
+                check_st60_data_send.check()
+
+            case "9" :
+                print("\nData Proceed flow control checking")
+                check_st65_data_proceed_flow.check()
+
+            case "10" :
+                print("\nStream completion checking")
+                check_st70_complete.check()
+
+            case "11" :
+                print("\nTerminate Due To Error checking")
+                check_st80_terminate_error.check()
+
+            case "12" :
+                print("\nPost-stream stability checking")
+                check_st85_stability.check()
+
+            case "13" :
+                print("\nOIR fallback checking")
+                check_st90_oir_fallback.check()
+
+            case "14" :
+                print("\nConcurrent streams (same node) checking")
+                check_st100_concurrent_same_node.check()
+
+            case "15" :
+                print("\nConcurrent streams (multi node) checking")
+                check_st110_concurrent_multi_node.check()
+
+            case "16" :
+                print("\nSustained transfer checking")
+                check_st120_sustained_transfer.check()
+
+            case "17" :
+                print("\nMinimum chunk send checking")
+                check_st130_min_chunk_send.check()
+
+            case "18" :
+                print("\nConcurrent sustained checking")
+                check_st140_concurrent_sustained.check()
+
+            case "19" :
+                print("\nAsymmetric buffers checking")
+                check_st150_asymmetric_buffers.check()
+
+            case "20" :
+                print("\nNegotiation enforcement checking")
+                check_st155_negotiation_enforcement.check()
+
+            case "21" :
+                print("\nZero-payload flush checking")
+                check_st170_zero_payload_flush.check()
+
+            case "22" :
+                print("\nInterleaved data send checking")
+                check_st180_interleaved_data_send.check()
+
+            case "23" :
+                print("\nSuggested DID checking")
+                check_st190_suggested_did.check()
+
+            case "24" :
+                print("\nComplete with byte count checking")
+                check_st200_complete_with_byte_count.check()
+
+            case "25" :
+                print("\nReject then retry checking")
+                check_st210_reject_then_retry.check()
+
+            case  "a" :
+                checkAll(logger)
+
+            case "q" | "quit" : return
+
+            case _ : continue
+
+    return
+
+if __name__ == "__main__":
+    result = main()
+    olcbchecker.setup.interface.close()
+    sys.exit(result)

--- a/olcbchecker/stream_utils.py
+++ b/olcbchecker/stream_utils.py
@@ -1,0 +1,662 @@
+"""
+Stream transport utilities for OlcbChecker memory configuration tests.
+
+Provides helpers for both stream source (checker sends data) and stream
+destination (checker receives data) roles, plus memory configuration
+stream command builders.
+
+Read Stream flow (checker is destination):
+    Checker sends Read Stream Command datagram -> node ACKs ->
+    node sends Stream Initiate Request -> checker replies accept ->
+    node sends Read Stream Reply datagram -> checker ACKs ->
+    node streams data -> checker sends Proceed at window boundaries ->
+    node sends Stream Data Complete
+
+Write Stream flow (checker is source):
+    Checker sends Write Stream Command datagram -> node ACKs ->
+    checker sends Stream Initiate Request -> node replies accept ->
+    checker streams data -> node sends Proceed at window boundaries ->
+    checker sends Stream Data Complete ->
+    node sends Write Stream Reply datagram -> checker ACKs
+"""
+
+import logging
+import time
+
+from openlcb.nodeid import NodeID
+from openlcb.message import Message
+from openlcb.mti import MTI
+
+from queue import Empty
+
+import olcbchecker
+
+# Module-level cache for stream support query results
+_stream_support_cache = {}
+
+# Checker's next destination stream ID counter (for when checker is
+# the stream destination and must assign a DID)
+_next_checker_did = 0x01
+
+
+def _get_next_checker_did():
+    """Allocate a destination stream ID for the checker."""
+    global _next_checker_did
+    did = _next_checker_did
+    _next_checker_did += 1
+    if _next_checker_did >= 0xFF:
+        _next_checker_did = 0x01
+    return did
+
+
+# ---------------------------------------------------------------------------
+# Config Options query
+# ---------------------------------------------------------------------------
+
+def query_stream_support(destination):
+    """Query Config Options to check if stream read/write is supported.
+
+    Sends a Get Configuration Options command (0x20, 0x80), parses the
+    reply, and returns True if the stream bit (0x01 in the write-lengths
+    byte) is set. Results are cached per destination.
+
+    Returns True/False, or None if the query failed.
+    """
+    cache_key = str(destination)
+    if cache_key in _stream_support_cache:
+        return _stream_support_cache[cache_key]
+
+    olcbchecker.purgeMessages()
+
+    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()),
+                      destination, [0x20, 0x80])
+    olcbchecker.sendMessage(message)
+
+    try:
+        reply = _get_reply_datagram(destination)
+    except Exception:
+        _stream_support_cache[cache_key] = None
+        return None
+
+    if len(reply.data) < 5:
+        _stream_support_cache[cache_key] = False
+        return False
+
+    # Byte 4 is the write-lengths byte; bit 0 = stream support
+    stream_supported = bool(reply.data[4] & 0x01)
+    _stream_support_cache[cache_key] = stream_supported
+    return stream_supported
+
+
+# ---------------------------------------------------------------------------
+# Datagram helpers (shared by stream command flows)
+# ---------------------------------------------------------------------------
+
+def _get_reply_datagram(destination):
+    """Wait for Datagram Received OK then the reply datagram.
+
+    Sends Datagram Received OK for the reply. Returns the reply message.
+    Raises Exception on timeout or rejection.
+    """
+    # Wait for Datagram Received OK or Rejected
+    while True:
+        try:
+            received = olcbchecker.getMessage()
+            if received.mti not in (MTI.Datagram_Received_OK,
+                                    MTI.Datagram_Rejected):
+                continue
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+            if received.mti == MTI.Datagram_Received_OK:
+                break
+            else:
+                raise Exception("Datagram rejected")
+        except Empty:
+            raise Exception("No reply to datagram")
+
+    # Wait for the reply datagram
+    while True:
+        try:
+            received = olcbchecker.getMessage()
+            if received.mti != MTI.Datagram:
+                continue
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+
+            ack = Message(MTI.Datagram_Received_OK,
+                          NodeID(olcbchecker.ownnodeid()), destination, [0])
+            olcbchecker.sendMessage(ack)
+            return received
+        except Empty:
+            raise Exception("No reply datagram received")
+
+
+def _wait_datagram_ok(destination):
+    """Wait for Datagram Received OK. Returns the flags byte.
+
+    Raises Exception on rejection or timeout.
+    """
+    while True:
+        try:
+            received = olcbchecker.getMessage(2.0)
+            if received.mti not in (MTI.Datagram_Received_OK,
+                                    MTI.Datagram_Rejected):
+                continue
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+            if received.mti == MTI.Datagram_Rejected:
+                raise Exception("Datagram rejected")
+            flags = received.data[0] if received.data else 0
+            return flags
+        except Empty:
+            raise Exception("No Datagram Received OK")
+
+
+# ---------------------------------------------------------------------------
+# Memory config stream command builders
+# ---------------------------------------------------------------------------
+
+def build_read_stream_command(space, offset, length, dest_stream_id):
+    """Build datagram payload for a Read Stream Command.
+
+    Args:
+        space: Address space number (0xFF, 0xFE, 0xFD, or explicit)
+        offset: 32-bit starting address
+        length: 32-bit read count (0 = read to end of space)
+        dest_stream_id: Suggested destination stream ID (0xFF if none)
+
+    Returns:
+        List of bytes for the datagram payload.
+
+    Format per MemoryConfigurationS section 4.6:
+        Byte 0: 0x20 (config mem prefix)
+        Byte 1: 0x60-0x63 (command with space encoding)
+        Bytes 2-5: Starting address (big-endian)
+        Byte 6: Address space (if not encoded in byte 1)
+        Byte 7/6: 0xFF (reserved, ignore on receipt)
+        Byte 8/7: Destination Stream ID
+        Bytes 9-12/8-11: Read count (big-endian, 4 bytes)
+    """
+    ad = [(offset >> 24) & 0xFF, (offset >> 16) & 0xFF,
+          (offset >> 8) & 0xFF, offset & 0xFF]
+
+    if space == 0xFF:
+        cmd = 0x63
+        payload = [0x20, cmd] + ad
+    elif space == 0xFE:
+        cmd = 0x62
+        payload = [0x20, cmd] + ad
+    elif space == 0xFD:
+        cmd = 0x61
+        payload = [0x20, cmd] + ad
+    else:
+        cmd = 0x60
+        payload = [0x20, cmd] + ad + [space]
+
+    payload.append(0xFF)  # reserved byte
+    payload.append(dest_stream_id)
+    payload.extend([(length >> 24) & 0xFF, (length >> 16) & 0xFF,
+                    (length >> 8) & 0xFF, length & 0xFF])
+    return payload
+
+
+def build_write_stream_command(space, offset, source_stream_id):
+    """Build datagram payload for a Write Stream Command.
+
+    Args:
+        space: Address space number
+        offset: 32-bit starting address
+        source_stream_id: Source stream ID assigned by the checker
+
+    Returns:
+        List of bytes for the datagram payload.
+
+    Format per MemoryConfigurationS section 4.11:
+        Byte 0: 0x20 (config mem prefix)
+        Byte 1: 0x20-0x23 (command with space encoding)
+        Bytes 2-5: Starting address (big-endian)
+        Byte 6: Address space (if not encoded in byte 1)
+        Byte 7/6: Source Stream ID
+    """
+    ad = [(offset >> 24) & 0xFF, (offset >> 16) & 0xFF,
+          (offset >> 8) & 0xFF, offset & 0xFF]
+
+    if space == 0xFF:
+        cmd = 0x23
+        payload = [0x20, cmd] + ad
+    elif space == 0xFE:
+        cmd = 0x22
+        payload = [0x20, cmd] + ad
+    elif space == 0xFD:
+        cmd = 0x21
+        payload = [0x20, cmd] + ad
+    else:
+        cmd = 0x20
+        payload = [0x20, cmd] + ad + [space]
+
+    payload.append(source_stream_id)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Stream destination functions (checker receives data from node)
+# ---------------------------------------------------------------------------
+
+def accept_incoming_stream(logger, destination, timeout=3.0):
+    """Wait for a Stream Initiate Request from the node and accept it.
+
+    The node is the stream source; the checker is the stream destination.
+    This is used after sending a Read Stream Command datagram.
+
+    Returns:
+        (sid, did, buf_size) on success -- sid is the node's source stream
+        ID, did is the checker's assigned destination stream ID, buf_size
+        is the negotiated buffer size.
+
+    Raises Exception on timeout or if the node sends an error.
+    """
+    while True:
+        try:
+            received = olcbchecker.getMessage(timeout)
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+
+            if received.mti == MTI.Stream_Initiate_Request:
+                if len(received.data) < 5:
+                    raise Exception("Stream Initiate Request too short")
+
+                proposed_size = (received.data[0] << 8) | received.data[1]
+                sid = received.data[4]
+
+                # Accept with proposed size (or cap to our buffer)
+                buf_size = min(proposed_size, 256)
+                did = _get_next_checker_did()
+
+                reply_data = [
+                    (buf_size >> 8) & 0xFF, buf_size & 0xFF,
+                    0x80, 0x00,  # flags: accept (0x8000)
+                    sid,
+                    did
+                ]
+                reply = Message(MTI.Stream_Initiate_Reply,
+                                NodeID(olcbchecker.ownnodeid()),
+                                destination, reply_data)
+                olcbchecker.sendMessage(reply)
+                return (sid, did, buf_size)
+
+            if received.mti == MTI.Terminate_Due_To_Error:
+                raise Exception("Node sent Terminate Due To Error "
+                                "instead of Stream Initiate Request")
+
+            continue
+
+        except Empty:
+            raise Exception("No Stream Initiate Request received")
+
+
+def receive_stream_data(logger, destination, sid, did, buf_size,
+                        timeout=3.0):
+    """Receive stream data from the node, sending Proceed as needed.
+
+    Accumulates all payload bytes until Stream Data Complete is received.
+
+    Args:
+        sid: Node's source stream ID
+        did: Checker's destination stream ID
+        buf_size: Negotiated buffer size (window for Proceed)
+        timeout: Seconds to wait for each message
+
+    Returns:
+        List of received payload bytes.
+
+    Raises Exception on timeout or protocol error.
+    """
+    collected = []
+    bytes_since_proceed = 0
+
+    while True:
+        try:
+            received = olcbchecker.getMessage(timeout)
+            if destination != received.source:
+                continue
+
+            if received.mti == MTI.Stream_Data_Send:
+                if len(received.data) < 1:
+                    continue
+                # Byte 0 is DID, rest is payload
+                payload = received.data[1:]
+                collected.extend(payload)
+                bytes_since_proceed += len(payload)
+
+                # Send Proceed when we have received buf_size bytes
+                if bytes_since_proceed >= buf_size:
+                    proceed = Message(
+                        MTI.Stream_Data_Proceed,
+                        NodeID(olcbchecker.ownnodeid()),
+                        destination, [sid, did])
+                    olcbchecker.sendMessage(proceed)
+                    bytes_since_proceed = 0
+
+                continue
+
+            if received.mti == MTI.Stream_Data_Complete:
+                return collected
+
+            if received.mti == MTI.Terminate_Due_To_Error:
+                raise Exception("Node sent Terminate Due To Error "
+                                "during stream data transfer")
+
+            continue
+
+        except Empty:
+            raise Exception(
+                "Timeout waiting for stream data ({} bytes received "
+                "so far)".format(len(collected)))
+
+
+# ---------------------------------------------------------------------------
+# Stream source functions (checker sends data to node)
+# ---------------------------------------------------------------------------
+
+def open_outbound_stream(logger, destination, proposed_size, sid):
+    """Initiate a stream from the checker to the node.
+
+    The checker is the stream source; the node is the destination.
+    This is used after sending a Write Stream Command datagram.
+
+    Args:
+        proposed_size: Max buffer size to propose
+        sid: Source stream ID assigned by the checker
+
+    Returns:
+        (buf_size, did) on acceptance -- buf_size is negotiated size,
+        did is the node's assigned destination stream ID.
+        (None, None) on rejection.
+    """
+    data = [(proposed_size >> 8) & 0xFF, proposed_size & 0xFF,
+            0x00, 0x00, sid]
+    message = Message(MTI.Stream_Initiate_Request,
+                      NodeID(olcbchecker.ownnodeid()), destination, data)
+    olcbchecker.sendMessage(message)
+
+    while True:
+        try:
+            received = olcbchecker.getMessage(2.0)
+            if destination != received.source:
+                continue
+
+            if received.mti == MTI.Optional_Interaction_Rejected:
+                return (None, None)
+
+            if received.mti == MTI.Stream_Initiate_Reply:
+                if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                    continue
+                if len(received.data) < 6:
+                    return (None, None)
+
+                buf_size = (received.data[0] << 8) | received.data[1]
+                flags = (received.data[2] << 8) | received.data[3]
+                did = received.data[5]
+
+                if (flags == 0x0000 or flags == 0x8000) and buf_size > 0:
+                    return (buf_size, did)
+                else:
+                    return (None, None)
+
+            continue
+
+        except Empty:
+            return (None, None)
+
+
+def send_stream_data(logger, destination, did, buf_size, data):
+    """Send data over an open stream, respecting flow control.
+
+    Sends data in chunks, waiting for Proceed after each buf_size
+    bytes sent.
+
+    Args:
+        did: Node's destination stream ID
+        buf_size: Negotiated buffer size
+        data: List of bytes to send
+
+    Raises Exception on timeout waiting for Proceed.
+    """
+    bytes_sent = 0
+    total = len(data)
+
+    while bytes_sent < total:
+        # Send up to buf_size bytes
+        window_sent = 0
+        while window_sent < buf_size and bytes_sent < total:
+            chunk_size = min(buf_size - window_sent, total - bytes_sent, 64)
+            payload = data[bytes_sent:bytes_sent + chunk_size]
+            msg_data = [did] + payload
+            message = Message(MTI.Stream_Data_Send,
+                              NodeID(olcbchecker.ownnodeid()),
+                              destination, msg_data)
+            olcbchecker.sendMessage(message)
+            bytes_sent += chunk_size
+            window_sent += chunk_size
+
+        # If we have more data, wait for Proceed
+        if bytes_sent < total:
+            if not _wait_for_proceed(destination, buf_size):
+                raise Exception(
+                    "No Stream Data Proceed after sending {} bytes"
+                    .format(bytes_sent))
+
+
+def _wait_for_proceed(destination, buf_size, timeout=3.0):
+    """Wait for a Stream Data Proceed message. Returns True on success."""
+    while True:
+        try:
+            received = olcbchecker.getMessage(timeout)
+            if destination != received.source:
+                continue
+            if received.mti == MTI.Stream_Data_Proceed:
+                return True
+            if received.mti == MTI.Terminate_Due_To_Error:
+                return False
+            continue
+        except Empty:
+            return False
+
+
+def close_stream(logger, destination, sid, did):
+    """Send Stream Data Complete to close an open stream.
+
+    Args:
+        sid: Source stream ID
+        did: Destination stream ID
+    """
+    complete = Message(MTI.Stream_Data_Complete,
+                       NodeID(olcbchecker.ownnodeid()),
+                       destination, [sid, did])
+    olcbchecker.sendMessage(complete)
+    time.sleep(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Combined memory config stream operations
+# ---------------------------------------------------------------------------
+
+def read_via_stream(logger, destination, space, offset, length):
+    """Perform a complete Read Stream operation.
+
+    Sends Read Stream Command datagram, accepts the incoming stream from
+    the node (node is source, checker is destination), receives the Read
+    Stream Reply datagram, collects all streamed data, and returns it.
+
+    Args:
+        space: Address space (0xFF, 0xFE, 0xFD, etc.)
+        offset: Starting address
+        length: Number of bytes to read (0 = read to end)
+
+    Returns:
+        List of received data bytes.
+
+    Raises Exception on any protocol failure.
+    """
+    olcbchecker.purgeMessages()
+
+    dest_stream_id = _get_next_checker_did()
+
+    # Step 1: Send Read Stream Command datagram
+    payload = build_read_stream_command(space, offset, length,
+                                        dest_stream_id)
+    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()),
+                      destination, payload)
+    olcbchecker.sendMessage(message)
+
+    # Step 2: Wait for Datagram Received OK
+    flags = _wait_datagram_ok(destination)
+
+    # Step 3: Accept incoming stream (node is source)
+    sid, did, buf_size = accept_incoming_stream(logger, destination)
+
+    # Step 4: Wait for Read Stream Reply datagram from node
+    reply = _wait_for_read_stream_reply(destination)
+    if reply is None:
+        raise Exception("No Read Stream Reply datagram received")
+
+    # Check for failure in the reply
+    reply_cmd = reply.data[1]
+    if (reply_cmd & 0x08) != 0:
+        # Fail bit set
+        error_msg = "Read Stream Reply indicates failure"
+        if len(reply.data) >= 9:
+            error_code = (reply.data[7] << 8) | reply.data[8]
+            error_msg += " (error 0x{:04X})".format(error_code)
+        raise Exception(error_msg)
+
+    # Step 5: Receive stream data
+    data = receive_stream_data(logger, destination, sid, did, buf_size)
+
+    return data
+
+
+def _wait_for_read_stream_reply(destination, timeout=3.0):
+    """Wait for a Read Stream Reply datagram from the node.
+
+    The reply is a datagram with command byte 0x70-0x7B.
+    Sends Datagram Received OK in response.
+
+    Returns the reply message, or None on timeout.
+    """
+    while True:
+        try:
+            received = olcbchecker.getMessage(timeout)
+            if received.mti != MTI.Datagram:
+                continue
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+
+            # Verify it is a Read Stream Reply (0x70-0x7B)
+            if len(received.data) >= 2:
+                cmd = received.data[1]
+                if (cmd & 0xF0) == 0x70:
+                    ack = Message(MTI.Datagram_Received_OK,
+                                  NodeID(olcbchecker.ownnodeid()),
+                                  destination, [0])
+                    olcbchecker.sendMessage(ack)
+                    return received
+
+            continue
+        except Empty:
+            return None
+
+
+def write_via_stream(logger, destination, space, offset, data):
+    """Perform a complete Write Stream operation.
+
+    Sends Write Stream Command datagram, opens an outbound stream to the
+    node (checker is source, node is destination), sends data, closes the
+    stream, and waits for the Write Stream Reply datagram.
+
+    Args:
+        space: Address space
+        offset: Starting address
+        data: List of bytes to write
+
+    Raises Exception on any protocol failure.
+    """
+    olcbchecker.purgeMessages()
+
+    sid = 0xA0  # checker's source stream ID for writes
+
+    # Step 1: Send Write Stream Command datagram
+    payload = build_write_stream_command(space, offset, sid)
+    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()),
+                      destination, payload)
+    olcbchecker.sendMessage(message)
+
+    # Step 2: Wait for Datagram Received OK
+    flags = _wait_datagram_ok(destination)
+
+    # Step 3: Open outbound stream (checker is source)
+    buf_size, did = open_outbound_stream(logger, destination, 256, sid)
+    if buf_size is None:
+        raise Exception("Node rejected stream for Write Stream operation")
+
+    # Step 4: Send data
+    send_stream_data(logger, destination, did, buf_size, data)
+
+    # Step 5: Close stream
+    close_stream(logger, destination, sid, did)
+
+    # Step 6: Wait for Write Stream Reply datagram
+    reply = _wait_for_write_stream_reply(destination)
+    if reply is None:
+        raise Exception("No Write Stream Reply datagram received")
+
+    # Check for failure
+    reply_cmd = reply.data[1]
+    if (reply_cmd & 0x08) != 0:
+        error_msg = "Write Stream Reply indicates failure"
+        if len(reply.data) >= 9:
+            error_code = (reply.data[7] << 8) | reply.data[8]
+            error_msg += " (error 0x{:04X})".format(error_code)
+        raise Exception(error_msg)
+
+
+def _wait_for_write_stream_reply(destination, timeout=5.0):
+    """Wait for a Write Stream Reply datagram from the node.
+
+    The reply is a datagram with command byte 0x30-0x3B.
+    Sends Datagram Received OK in response.
+
+    Returns the reply message, or None on timeout.
+    """
+    while True:
+        try:
+            received = olcbchecker.getMessage(timeout)
+            if received.mti != MTI.Datagram:
+                continue
+            if destination != received.source:
+                continue
+            if NodeID(olcbchecker.ownnodeid()) != received.destination:
+                continue
+
+            if len(received.data) >= 2:
+                cmd = received.data[1]
+                if (cmd & 0xF0) == 0x30:
+                    ack = Message(MTI.Datagram_Received_OK,
+                                  NodeID(olcbchecker.ownnodeid()),
+                                  destination, [0])
+                    olcbchecker.sendMessage(ack)
+                    return received
+
+            continue
+        except Empty:
+            return None

--- a/openlcb/canbus/canlink.py
+++ b/openlcb/canbus/canlink.py
@@ -246,6 +246,17 @@ class CanLink(LinkLayer):
             self.aliasToNodeID[frame.header & 0xFFF] = sourceID
             self.nodeIdToAlias[sourceID] = frame.header & 0xFFF
 
+        #    handle Stream Data Send (frame type 7) separately
+        if mti == MTI.Stream_Data_Send:
+            destAlias = (frame.header & 0x00_FFF_000) >> 12
+            if destAlias in self.aliasToNodeID:
+                destID = self.aliasToNodeID[destAlias]
+            else:
+                destID = NodeID(0)
+            msg = Message(mti, sourceID, destID, frame.data)
+            self.fireListeners(msg)
+            return
+
         destID = NodeID(0)
         #    handle destination for addressed messages
         dgCode = frame.header & 0x00F_000_000
@@ -367,6 +378,25 @@ class CanLink(LinkLayer):
             self.fireListeners(msg)
 
     def sendMessage(self, msg):
+        #    special case for stream data send (CAN frame type 7)
+        if msg.mti == MTI.Stream_Data_Send:
+            header = 0x1F_000_000
+            sssAlias = self.nodeIdToAlias.get(msg.source, 0)
+            dddAlias = self.nodeIdToAlias.get(msg.destination, 0)
+            header |= (sssAlias & 0xFFF)
+            header |= ((dddAlias & 0xFFF) << 12)
+            did = msg.data[0]
+            payload = msg.data[1:]
+            if len(payload) == 0:
+                frame = CanFrame(header, [did])
+                self.link.sendCanFrame(frame)
+            else:
+                for i in range(0, len(payload), 7):
+                    chunk = [did] + payload[i:i + 7]
+                    frame = CanFrame(header, chunk)
+                    self.link.sendCanFrame(frame)
+            return
+
         #    special case for datagram
         if msg.mti == MTI.Datagram:
             header = 0x10_00_00_00
@@ -618,7 +648,10 @@ class CanLink(LinkLayer):
             #    datagram type - we don't address the subtypes here
             return MTI.Datagram
 
-        #    not handling reserver and stream type except to log
+        if frameType == 7:
+            return MTI.Stream_Data_Send
+
+        #    not handling reserved type except to log
         logging.warning("unhandled canMTI: {}, marked Unknown"
                         "".format(frame))
         return MTI.Unknown

--- a/openlcb/mti.py
+++ b/openlcb/mti.py
@@ -46,6 +46,12 @@ class MTI(Enum):
     Datagram_Received_OK               = 0x0A28
     Datagram_Rejected                  = 0x0A48
 
+    Stream_Initiate_Request            = 0x0CC8
+    Stream_Initiate_Reply              = 0x0868
+    Stream_Data_Send                   = 0x1F88
+    Stream_Data_Proceed                = 0x0888
+    Stream_Data_Complete               = 0x08A8
+
     Unknown                            = 0x0008   # make this addressed so that it;s individually processed  # noqa: E501
 
     # These are used for internal signalling and are not present in the MTI

--- a/plans/StreamTransportPlan.tex
+++ b/plans/StreamTransportPlan.tex
@@ -1,0 +1,356 @@
+\input{formattingHeader}
+
+\titleandheader{Checking the OpenLCB Stream Transport Protocol}
+
+\begin{document}
+\maketitle
+\thispagestyle{firststyle}
+
+\introductionCaveats
+    {https://nbviewer.org/github/openlcb/documents/blob/master/standards/StreamTransportS.pdf}
+    {Stream Transport Standard}.
+
+\section{Stream Transport Procedure}
+
+\checkProcedure{Stream Checking}
+
+A node which does not self-identify in PIP that it supports
+Stream Transport will be considered to have passed these checks.
+\pipsetFootnote
+
+The checker acts as the Source node (initiating streams to the DBC).
+The DBC is always the Destination node.  For nodes that do not support
+streams, we verify proper rejection.
+
+This plan does not check:
+\begin{enumerate}
+\item Streams initiated by the DBC as source.  Config-mem stream checks
+    exercise that path separately.
+\item CAN multi-frame assembly of 12-byte Initiate Requests.  The st040 check
+    sends a 12-byte request but does not explicitly verify CAN framing.
+\item Gateway buffer reduction (not testable from an end node).
+\item Early Proceed (implementation optimization, not a conformance requirement).
+\end{enumerate}
+
+All checks validated against PR \#189 (openlcb/documents), the authoritative
+spec revision.
+
+\subsection{Stream Initiate Request/Reply}
+
+This checks Standard sections 4.1, 4.2 and 7.1.
+
+The checker sends a Stream Initiate Request with a proposed buffer size of 256
+and Source Stream ID 0x01.  It then checks:
+\begin{enumerate}
+\item That a Stream Initiate Reply or Optional Interaction Rejected is received.
+\item If a Reply: length is at least 6 bytes, SID is echoed, DID is not 0xFF,
+    flags and buffer size are self-consistent.
+\item If accepted, the stream is closed with Stream Data Complete.
+\item A 30-second stability soak monitors for unexpected reboots.
+\end{enumerate}
+
+\subsection{Reject When Unsupported}
+
+This checks Standard section 7.1.
+
+If the DBC does not advertise Stream Transport in PIP, the checker sends a
+Stream Initiate Request and verifies the DBC rejects it with OIR or an error
+reply.
+
+\subsection{Buffer Negotiation}
+
+This checks Standard section 4.2.
+
+The checker opens streams with proposed buffer sizes of 64 and 1024.  For each:
+\begin{enumerate}
+\item Verifies the reply buffer size does not exceed the proposed size.
+\item Verifies the reply buffer size is greater than zero if accepted.
+\end{enumerate}
+
+\subsection{Minimum Buffer Size}
+
+This checks Standard section 4.2.
+
+The checker sends a Stream Initiate Request with buffer size 1.  Verifies
+acceptance with size 1 or a valid rejection.
+
+\subsection{Maximum Buffer Size}
+
+This checks Standard section 4.2.
+
+The checker sends a Stream Initiate Request with buffer size 0xFFFF.  Verifies
+the reply buffer does not exceed 0xFFFF and the node negotiates down to its
+capability.
+
+\subsection{Unknown Content UID}
+
+This checks Standard section 6.2.
+
+The checker sends a 12-byte Stream Initiate Request with a fabricated Content
+UID.  Accepts rejection with 0x1040 (unimplemented) or acceptance (both
+spec-legal).
+
+\subsection{Initiate Reply Format}
+
+This checks Standard sections 4.1 and 4.2.
+
+The checker sends an initiate with SID 0x42 and validates every field in the
+reply:
+\begin{enumerate}
+\item Length at least 6 bytes.
+\item Byte 4 echoes SID 0x42 exactly.
+\item Byte 5 (DID) in range 0x00--0xFE.
+\item If accept: flags 0x0000 or 0x8000, buffer greater than 0 and not
+    exceeding proposed.
+\item If reject: error code 0x1xxx or 0x2xxx, buffer 0.
+\end{enumerate}
+
+\subsection{Data Send and Proceed}
+
+This checks Standard sections 4.3, 4.4 and 6.3.
+
+The checker opens a stream, sends exactly MaxBufSize bytes, and verifies a
+Stream Data Proceed is received with correct SID and DID.  The stream is then
+closed.
+
+\subsection{Data Proceed Flow Control}
+
+This checks Standard section 6.3.
+
+The checker opens a stream and performs two consecutive buffer cycles:
+\begin{enumerate}
+\item Send MaxBufSize bytes, wait for Proceed.
+\item Send another MaxBufSize bytes, wait for second Proceed.
+\end{enumerate}
+Verifies no unsolicited errors during transfer.
+
+\subsection{Stream Completion}
+
+This checks Standard section 6.4.
+
+The checker opens a stream, sends a partial buffer (less than MaxBufSize),
+sends Stream Data Complete, verifies no errors, then reopens a new stream to
+confirm resources were freed.
+
+\subsection{Terminate Due To Error}
+
+This checks Standard section 6.4.
+
+The checker opens a stream, sends a Terminate Due To Error, verifies the node
+remains stable, then reopens a stream to confirm recovery.
+
+\subsection{Post-Stream Stability}
+
+This checks general robustness after stream operations.
+
+The checker opens and closes a stream, then monitors the node for 30 seconds,
+pinging every 10 seconds with Verify Node ID Addressed.  Watches for
+unexpected Initialization Complete messages.
+
+\subsection{OIR Fallback}
+
+This checks Standard section 7.1.
+
+When Stream Transport is in PIP, the checker sends a Stream Initiate Request
+and accepts either a Stream Initiate Reply or OIR as valid responses.
+
+\subsection{Concurrent Streams, Same Source Node}
+
+This checks Technical Note section 1 and section 2.3.1.
+
+The checker opens two concurrent streams (SID 0xA0 and 0xB0) to the DBC.
+If the second is rejected, the test passes with info (single-stream node).
+Otherwise:
+\begin{enumerate}
+\item Sends interleaved data on both streams.
+\item Verifies each Proceed carries the correct SID/DID for its stream.
+\item Repeats for a second cycle.
+\item Closes both streams.
+\end{enumerate}
+
+\subsection{Concurrent Streams, Different Source Nodes}
+
+This checks Technical Note section 2.3.1.
+
+The checker claims a second CAN alias (spoofed source node) and opens
+concurrent streams from both the real and spoofed nodes to the DBC, using the
+same SID (spec-legal since different source nodes).  Verifies the DBC tracks
+streams by (Source Node ID, SID) and does not confuse traffic from different
+sources.
+
+\subsection{Sustained Transfer}
+
+This checks Standard section 6.3.
+
+The checker opens a stream and runs 20 consecutive send/proceed cycles with
+zero delay between them.  Verifies the DBC does not leak memory, lose window
+count, or stall.  Reopens a stream afterward to confirm recovery.
+
+\subsection{Minimum Chunk Send}
+
+This checks Standard section 4.3.
+
+The checker sends MaxBufSize bytes as individual 1-byte payload Stream Data
+Send messages, maximizing the number of CAN frames per buffer window.
+Stresses the receive path and any internal reassembly.
+
+\subsection{Concurrent Sustained}
+
+This checks Standard section 6.3 and Technical Note section 1.
+
+Two concurrent streams both doing 10 sustained multi-cycle transfers
+simultaneously.  Stresses total buffer pool allocation.
+
+\subsection{Asymmetric Buffers}
+
+This checks Standard section 4.2.
+
+Two concurrent streams with different proposed buffer sizes (64 and 1024).
+Verifies the DBC tracks different window sizes and sends Proceed at the
+correct boundary for each stream independently.
+
+\subsection{Negotiation Enforcement}
+
+This checks Standard section 4.2.
+
+The checker proposes a large buffer (1024).  The DBC may negotiate down.
+The test sends exactly the negotiated amount and confirms Proceed arrives at
+the right boundary, not at the proposed size.
+
+\subsection{Zero-Payload Flush}
+
+This checks Standard section 6.3 and Technical Note section 2.4.3.
+
+The checker sends half a buffer window, then a zero-payload Stream Data Send
+(just the DID byte), then the remaining half.  Verifies Proceed arrives after
+the full MaxBufSize payload bytes (the flush does not count toward the buffer
+window).  Repeated for 2 cycles.
+
+\subsection{Interleaved Data Send}
+
+This checks Standard section 7.2 and Technical Note section 2.3.1.
+
+Two concurrent streams receive interleaved Stream Data Send messages within
+the same buffer window.  The checker alternates 32-byte chunks (A, B, A, B)
+until both windows are full.  Forces the DBC to track each stream's byte count
+independently.  Repeated for 2 cycles.
+
+\subsection{Suggested DID}
+
+This checks Standard section 4.1.
+
+The checker sends a Stream Initiate Request with a suggested DID of 0x42
+(byte 0 of the request).  Verifies the reply DID is in range 0x00--0xFE.
+The DBC may honor the suggestion or assign its own; both are valid.
+Then reopens with DID 0xFF (no suggestion) to confirm both paths work.
+
+\subsection{Complete with Byte Count}
+
+This checks Standard section 6.4.
+
+The checker tests both forms of Stream Data Complete:
+\begin{enumerate}
+\item With the optional 4-byte total byte count appended.
+\item Without the byte count (2 bytes only).
+\end{enumerate}
+For each form, sends one full buffer, waits for Proceed, sends Complete,
+verifies no errors, and reopens a stream to confirm resources were freed.
+
+\subsection{Reject Then Retry}
+
+This checks Standard section 6.2.
+
+The checker opens streams until one is rejected (up to 4 attempts).  If no
+rejection occurs, the test passes (deep pool node).  Otherwise:
+\begin{enumerate}
+\item Closes one open stream to free resources.
+\item Retries the rejected initiate.
+\item Verifies the retry succeeds.
+\item Closes all streams.
+\end{enumerate}
+
+\section{Compliance Matrix}
+
+The following table maps spec requirements to the checks that cover them.
+
+\subsection{Covered Requirements}
+
+\begin{tabular}{|p{8cm}|p{5cm}|}
+\hline
+\textbf{Spec Requirement} & \textbf{Check(s)} \\
+\hline
+S4.1 Stream Initiate Request format & st010, st050, st040 \\
+\hline
+S4.1 Suggested DID in Initiate Request & st190 \\
+\hline
+S4.2 Stream Initiate Reply format, error codes, SID echo, DID range & st010, st050, st060 \\
+\hline
+S4.2 Accept: buf $\leq$ proposed, buf $>$ 0 & st030, st035, st037, st155 \\
+\hline
+S4.2 Reject: permanent/temporary error codes, buf = 0 & st020, st050 \\
+\hline
+S4.3 Stream Data Send with DID byte 0 & st060, st065, st070 \\
+\hline
+S4.4 Stream Data Proceed: SID/DID correct & st060, st065, st100, st140 \\
+\hline
+S4.6 Stream Data Complete closes stream & st070, st080 \\
+\hline
+S5 States: Initiated $\rightarrow$ Open transition & st010 \\
+\hline
+S5 States: Open $\rightarrow$ Closed via Complete & st070 \\
+\hline
+S5 States: Open $\rightarrow$ Closed via TDE & st080 \\
+\hline
+S6.1 Opening with announcement (via config-mem) & (memory config stream checks) \\
+\hline
+S6.2 Opening without announcement (Content UID) & st040 \\
+\hline
+S6.2 Unknown Content UID $\rightarrow$ 0x1040 or accept & st040 \\
+\hline
+S6.2 Reject then retry after freeing resources & st210 \\
+\hline
+S6.3 Data transfer: send up to MaxBufSize, wait for Proceed & st060, st065 \\
+\hline
+S6.3 Proceed extends window by MaxBufSize & st065, st120, st155 \\
+\hline
+S6.4 Stream Data Complete closes stream & st070 \\
+\hline
+S6.4 Stream Data Complete with optional byte count & st200 \\
+\hline
+S6.4 TDE closes stream & st080 \\
+\hline
+S7.1 CAN Frame Type 7: DID in byte 0, payload in bytes 1--7 & st060, st110, st125 \\
+\hline
+S7.2 Message-level interleaving across concurrent streams & st180 \\
+\hline
+TN1 Up to 255 concurrent streams per node pair & st100 (2 streams) \\
+\hline
+TN2.3.1 Stream identified by (SrcNodeID, DstNodeID, SID) & st110 \\
+\hline
+TN2.4.3 Zero-payload flush & st170 \\
+\hline
+Post-operation stability & st085 \\
+\hline
+OIR as valid fallback & st090 \\
+\hline
+Resource recovery after close & st070, st120, st140 \\
+\hline
+\end{tabular}
+
+\subsection{Not Covered}
+
+\begin{tabular}{|p{4cm}|p{2.5cm}|p{6cm}|}
+\hline
+\textbf{Gap} & \textbf{Spec Ref} & \textbf{Notes} \\
+\hline
+12-byte Initiate Request CAN multi-frame & S7.2 & st040 sends it but does not explicitly verify CAN framing. \\
+\hline
+Gateway buffer reduction & S6.5 & Not testable from an end node. \\
+\hline
+Proceed sent early & TN2.4.4, S8.4 & Implementation optimization, not a conformance requirement. \\
+\hline
+Stream from DBC as source & S6.1, S6.3 & Config-mem stream checks cover this path. \\
+\hline
+\end{tabular}
+
+\end{document}


### PR DESCRIPTION
…streams when available

- 22 new stream transport test cases (check_st10 through check_st210)
- Stream test controller and utilities (control_stream.py, olcbchecker/stream_utils.py)
- Updated memory config tests to use datagram and/or streams if available
- Updated canlink.py and mti.py with stream support
- Stream transport test plan (plans/StreamTransportPlan.tex)